### PR TITLE
Add wheel build configuration to CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,9 @@
 name: Release Artifacts
 on:
   push:
-    tags:
-      - '*'
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
 jobs:
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
@@ -24,31 +25,3 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
-      - name: Publish to PyPi
-        env:
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_USERNAME: nonhermitian
-        run: twine upload ./wheelhouse/*whl
-  sdist-build:
-    name: Build and Publish Release Artifacts
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        name: Install Python
-        with:
-          python-version: '3.9'
-      - name: Install Deps
-        run: pip install -U twine cython numpy
-      - name: Build Artifacts
-        run: |
-          python setup.py sdist
-        shell: bash
-      - uses: actions/upload-artifact@v2
-        with:
-          path: ./dist/mthree*
-      - name: Publish to PyPi
-        env:
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_USERNAME: nonhermitian
-        run: twine upload dist/mthree*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,9 @@ jobs:
         env:
           CIBW_ARCHS_MACOS: x86_64 universal2
           CIBW_TEST_REQUIRES: pytest
-          CIBW_TEST_COMMAND: pytest -p no:warnings --pyargs {project}/mthree/test
+          CIBW_TEST_COMMAND: pytest -p no:warnings --pyargs {project}/test
           CIBW_ENVIRONMENT: MTHREE_OPENMP=1
+          CIBW_BEFORE_TEST: cp -r {project}/mthree/test {project}/.
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         env:
           CIBW_ARCHS_MACOS: x86_64 universal2
           CIBW_TEST_REQUIRES: pytest
-          CIBW_TEST_COMMAND: pytest -p no:warnings --pyargs {project}/test
+          CIBW_TEST_COMMAND: pytest -p no:warnings {project}/test
           CIBW_ENVIRONMENT: MTHREE_OPENMP=1
           CIBW_BEFORE_TEST: cp -r {project}/mthree/test {project}/.
       - uses: actions/upload-artifact@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
           CIBW_TEST_REQUIRES: pytest qiskit-aer
           CIBW_TEST_COMMAND: pytest -p no:warnings /mthree_test
           CIBW_ENVIRONMENT: MTHREE_OPENMP=1
-          CIBW_BEFORE_TEST: cp -r {project}/mthree/test /mthree_test && rm /mthree_test/test_converters.py && rm /mthree_test/test/test_columns.py
+          CIBW_BEFORE_TEST: cp -r {project}/mthree/test /mthree_test && rm /mthree_test/test_converters.py && rm /mthree_test/test_columns.py
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,9 +20,9 @@ jobs:
         env:
           CIBW_ARCHS_MACOS: x86_64 universal2
           CIBW_TEST_REQUIRES: pytest
-          CIBW_TEST_COMMAND: pytest -p no:warnings {project}/test
+          CIBW_TEST_COMMAND: pytest -p no:warnings ./test
           CIBW_ENVIRONMENT: MTHREE_OPENMP=1
-          CIBW_BEFORE_TEST: cp -r {project}/mthree/test {project}/.
+          CIBW_BEFORE_TEST: cp -r {project}/mthree/test . && rm ./test/test_converters.py && rm ./test/test_columns.py && pip install -r {project}/requirements-dev.txt
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
           CIBW_TEST_REQUIRES: pytest qiskit-aer
           CIBW_TEST_COMMAND: pytest -p no:warnings /mthree_test
           CIBW_ENVIRONMENT: MTHREE_OPENMP=1
-          CIBW_BEFORE_TEST: cp -r {project}/mthree/test /mthree_test && rm /mthree_test/test_converters.py && rm /mthree_test/test_columns.py
+          CIBW_BEFORE_TEST: cp -r {project}/mthree/test /mthree_test && rm -f /mthree_test/test_converters.py && rm -f /mthree_test/test_columns.py
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,11 +21,11 @@ jobs:
           CIBW_ARCHS_MACOS: x86_64 universal2
           CIBW_TEST_REQUIRES: pytest qiskit-aer
           CIBW_TEST_COMMAND_LINUX: pytest -p no:warnings /mthree_test
-          CIBW_TEST_COMMAND_WINDOWS: pytest -p no:warnings /mthree_test
+          CIBW_TEST_COMMAND_WINDOWS: pytest -p no:warnings C:\Users\RUNNER~1\AppData\Local\Temp\mthree_test
           CIBW_TEST_COMMAND_MACOS:  pytest -p no:warnings /tmp/mthree_test
           CIBW_ENVIRONMENT: MTHREE_OPENMP=1
           CIBW_BEFORE_TEST_LINUX: rm -rf /mthree_test && cp -r {project}/mthree/test /mthree_test && rm -f /mthree_test/test_converters.py && rm -f /mthree_test/test_columns.py
-          CIBW_BEFORE_TEST_WINDOWS: rm -rf /mthree_test && cp -r {project}/mthree/test /mthree_test && rm -f /mthree_test/test_converters.py && rm -f /mthree_test/test_columns.py && pip install --prefer-binary orjson
+          CIBW_BEFORE_TEST_WINDOWS: rm -rf C:\Users\RUNNER~1\AppData\Local\Temp\mthree_test && cp -r {project}/mthree/test C:\Users\RUNNER~1\AppData\Local\Temp\mthree_test && rm -f C:\Users\RUNNER~1\AppData\Local\Temp\mthree_test\test_converters.py && rm -f C:\Users\RUNNER~1\AppData\Local\Temp\mthree_test\test_columns.py && pip install --prefer-binary orjson
           CIBW_BEFORE_TEST_MACOS: rm -rf /tmp/mthree_test && cp -r {project}/mthree/test /tmp/mthree_test && rm -f /tmp/mthree_test/test_converters.py && rm -f /tmp/mthree_test/test_columns.py
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.1.1
         env:
+          CIBW_BEFORE_ALL_LINUX: yum install -y wget && wget https://sh.rustup.rs -O rustup.sh && sh rustup.sh -y --default-toolchain nightly
           CIBW_SKIP: "*-win32 *-manylinux_i686"
           CIBW_ARCHS_MACOS: x86_64 universal2
           CIBW_TEST_REQUIRES: pytest qiskit-aer

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.1.1
         env:
-          CIBW_BEFORE_ALL_LINUX: yum install -y wget && wget https://sh.rustup.rs -O rustup.sh && sh rustup.sh -y --default-toolchain nightly
+          CIBW_BEFORE_ALL_LINUX: yum install -y wget && wget https://sh.rustup.rs -O rustup.sh && sh rustup.sh -y --default-toolchain nightly && source $HOME/.cargo/env
           CIBW_SKIP: "*-win32 *-manylinux_i686"
           CIBW_ARCHS_MACOS: x86_64 universal2
           CIBW_TEST_REQUIRES: pytest qiskit-aer

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,24 +14,19 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: nightly
-          override: true
-          profile: default
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.1.1
         env:
+          CIBW_SKIP: "*-win32 *-manylinux_i686"
           CIBW_ARCHS_MACOS: x86_64 universal2
           CIBW_TEST_REQUIRES: pytest qiskit-aer
           CIBW_TEST_COMMAND_LINUX: pytest -p no:warnings /mthree_test
           CIBW_TEST_COMMAND_WINDOWS: pytest -p no:warnings /mthree_test
           CIBW_TEST_COMMAND_MACOS:  pytest -p no:warnings /tmp/mthree_test
           CIBW_ENVIRONMENT: MTHREE_OPENMP=1
-          CIBW_BEFORE_TEST_LINUX: cp -r {project}/mthree/test /mthree_test && rm -f /mthree_test/test_converters.py && rm -f /mthree_test/test_columns.py
-          CIBW_BEFORE_TEST_WINDOWS: cp -r {project}/mthree/test /mthree_test && rm -f /mthree_test/test_converters.py && rm -f /mthree_test/test_columns.py && pip install --prefer-binary orjson
-          CIBW_BEFORE_TEST_MACOS: cp -r {project}/mthree/test /tmp/mthree_test && rm -f /tmp/mthree_test/test_converters.py && rm -f /tmp/mthree_test/test_columns.py
+          CIBW_BEFORE_TEST_LINUX: rm -rf /mthree_test && cp -r {project}/mthree/test /mthree_test && rm -f /mthree_test/test_converters.py && rm -f /mthree_test/test_columns.py
+          CIBW_BEFORE_TEST_WINDOWS: rm -rf /mthree_test && cp -r {project}/mthree/test /mthree_test && rm -f /mthree_test/test_converters.py && rm -f /mthree_test/test_columns.py && pip install --prefer-binary orjson
+          CIBW_BEFORE_TEST_MACOS: rm -rf /tmp/mthree_test && cp -r {project}/mthree/test /tmp/mthree_test && rm -f /tmp/mthree_test/test_converters.py && rm -f /tmp/mthree_test/test_columns.py
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           CIBW_TEST_COMMAND_MACOS:  pytest -p no:warnings /tmp/mthree_test
           CIBW_ENVIRONMENT: MTHREE_OPENMP=1
           CIBW_BEFORE_TEST_LINUX: cp -r {project}/mthree/test /mthree_test && rm -f /mthree_test/test_converters.py && rm -f /mthree_test/test_columns.py
-          CIBW_BEFORE_TEST_WINDOWS: cp -r {project}/mthree/test /mthree_test && rm -f /mthree_test/test_converters.py && rm -f /mthree_test/test_columns.py
+          CIBW_BEFORE_TEST_WINDOWS: cp -r {project}/mthree/test /mthree_test && rm -f /mthree_test/test_converters.py && rm -f /mthree_test/test_columns.py && pip install --prefer-binary orjson
           CIBW_BEFORE_TEST_MACOS: cp -r {project}/mthree/test /tmp/mthree_test && rm -f /tmp/mthree_test/test_converters.py && rm -f /tmp/mthree_test/test_columns.py
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,7 +4,32 @@ on:
     tags:
       - '*'
 jobs:
-  wheel-build:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, windows-2019, macos-10.15]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.1.1
+        env:
+          CIBW_ARCHS_MACOS: x86_64 universal2
+          CIBW_TEST_REQUIRES: pytest
+          CIBW_TEST_COMMAND: pytest -p no:warnings --pyargs {package}/mthree/tests
+          CIBW_ENVIRONMENT: MTHREE_OPENMP=1
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./wheelhouse/*.whl
+      - name: Publish to PyPi
+        env:
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          TWINE_USERNAME: nonhermitian
+        run: twine upload ./wheelhouse/*whl
+  sdist-build:
     name: Build and Publish Release Artifacts
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,12 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          override: true
+          profile: default
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.1.1
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,9 +20,13 @@ jobs:
         env:
           CIBW_ARCHS_MACOS: x86_64 universal2
           CIBW_TEST_REQUIRES: pytest qiskit-aer
-          CIBW_TEST_COMMAND: pytest -p no:warnings /mthree_test
+          CIBW_TEST_COMMAND_LINUX: pytest -p no:warnings /mthree_test
+          CIBW_TEST_COMMAND_WINDOWS: pytest -p no:warnings /mthree_test
+          CIBW_TEST_COMMAND_MACOS:  pytest -p no:warnings /tmp/mthree_test
           CIBW_ENVIRONMENT: MTHREE_OPENMP=1
-          CIBW_BEFORE_TEST: cp -r {project}/mthree/test /mthree_test && rm -f /mthree_test/test_converters.py && rm -f /mthree_test/test_columns.py
+          CIBW_BEFORE_TEST_LINUX: cp -r {project}/mthree/test /mthree_test && rm -f /mthree_test/test_converters.py && rm -f /mthree_test/test_columns.py
+          CIBW_BEFORE_TEST_WINDOWS: cp -r {project}/mthree/test /mthree_test && rm -f /mthree_test/test_converters.py && rm -f /mthree_test/test_columns.py
+          CIBW_BEFORE_TEST_MACOS: cp -r {project}/mthree/test /tmp/mthree_test && rm -f /tmp/mthree_test/test_converters.py && rm -f /tmp/mthree_test/test_columns.py
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         env:
           CIBW_ARCHS_MACOS: x86_64 universal2
           CIBW_TEST_REQUIRES: pytest
-          CIBW_TEST_COMMAND: pytest -p no:warnings --pyargs {package}/mthree/tests
+          CIBW_TEST_COMMAND: pytest -p no:warnings --pyargs {package}/mthree/test
           CIBW_ENVIRONMENT: MTHREE_OPENMP=1
       - uses: actions/upload-artifact@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,10 +19,10 @@ jobs:
         uses: pypa/cibuildwheel@v2.1.1
         env:
           CIBW_ARCHS_MACOS: x86_64 universal2
-          CIBW_TEST_REQUIRES: pytest
-          CIBW_TEST_COMMAND: pytest -p no:warnings ./test
+          CIBW_TEST_REQUIRES: pytest qiskit-aer
+          CIBW_TEST_COMMAND: pytest -p no:warnings /mthree_test
           CIBW_ENVIRONMENT: MTHREE_OPENMP=1
-          CIBW_BEFORE_TEST: cp -r {project}/mthree/test . && rm ./test/test_converters.py && rm ./test/test_columns.py && pip install -r {project}/requirements-dev.txt
+          CIBW_BEFORE_TEST: cp -r {project}/mthree/test /mthree_test && rm /mthree_test/test_converters.py && rm /mthree_test/test/test_columns.py
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.1.1
         env:
+          CIBW_SKIP: "cp310-* pp*"
           CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64 *-win32 *-manylinux_i686 cp39-manylinux*"
           CIBW_ARCHS_MACOS: x86_64 universal2
           CIBW_TEST_REQUIRES: pytest qiskit-aer

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.1.1
         env:
-          CIBW_BEFORE_ALL_LINUX: yum install -y wget && wget https://sh.rustup.rs -O rustup.sh && sh rustup.sh -y --default-toolchain nightly && source $HOME/.cargo/env
-          CIBW_SKIP: "*-win32 *-manylinux_i686"
+          CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64 *-win32 *-manylinux_i686 cp39-manylinux*"
           CIBW_ARCHS_MACOS: x86_64 universal2
           CIBW_TEST_REQUIRES: pytest qiskit-aer
           CIBW_TEST_COMMAND_LINUX: pytest -p no:warnings /mthree_test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         env:
           CIBW_ARCHS_MACOS: x86_64 universal2
           CIBW_TEST_REQUIRES: pytest
-          CIBW_TEST_COMMAND: pytest -p no:warnings --pyargs {package}/mthree/test
+          CIBW_TEST_COMMAND: pytest -p no:warnings --pyargs {project}/mthree/test
           CIBW_ENVIRONMENT: MTHREE_OPENMP=1
       - uses: actions/upload-artifact@v2
         with:

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,4 @@ cython>=0.29
 qiskit-terra>=0.16
 qiskit-ibmq-provider>=0.11
 psutil
-orjson>=3.5
+orjson>=3.0.0

--- a/setup.py
+++ b/setup.py
@@ -39,13 +39,8 @@ MICRO = 0
 ISRELEASED = False
 VERSION = '%d.%d.%d' % (MAJOR, MINOR, MICRO)
 
-REQUIREMENTS = ['numpy>=1.17',
-                'scipy>=1.3',
-                'cython>=0.29',
-                'qiskit-terra>=0.16',
-                'qiskit-ibmq-provider>=0.11',
-                'psutil'
-               ]
+with open("requirements.txt") as f:
+    REQUIREMENTS = f.read().splitlines()
 
 PACKAGES = setuptools.find_packages()
 PACKAGE_DATA = {'mthree': ['*.pxd'],

--- a/setup.py
+++ b/setup.py
@@ -68,13 +68,13 @@ for _arg in sys.argv:
     if _arg.startswith("--with-"):
         _options = _arg.split("--with-")[1].split(",")
         sys.argv.remove(_arg)
-        if "openmp" in _options:
+        if "openmp" in _options or os.getenv("MTHREE_OPENMP", False):
             if sys.platform == 'win32':
                 OPTIONAL_FLAGS = ['/openmp']
             else:
                 OPTIONAL_FLAGS = ['-fopenmp']
                 OPTIONAL_ARGS = OPTIONAL_FLAGS
-        if "native" in _options:
+        if "native" in _options or os.getenv("MTHREE_NATIVE", False):
             OPTIONAL_FLAGS.append('-march=native')
 
 INCLUDE_DIRS = [np.get_include()]
@@ -203,10 +203,9 @@ setuptools.setup(
     url="",
     author="Paul Nation",
     author_email="paul.nation@ibm.com",
-    license="For internal IBM Quantum use only.",
+    license="Apache 2.0",
     classifiers=[
-        "Environment :: Web Environment",
-        "License :: Other/Proprietary License",
+        "License :: OSI Approved :: Apache Software License",
         "Intended Audience :: Developers",
         "Intended Audience :: Science/Research",
         "Operating System :: Microsoft :: Windows",
@@ -215,6 +214,8 @@ setuptools.setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
         "Topic :: Scientific/Engineering",
     ],
     cmdclass={'lint': PylintCommand, 'style': StyleCommand},


### PR DESCRIPTION
This commit adds a new job to the release CI to leverage cibuildwheel to
build and publish portable wheels to PyPI. Right now at release time we
only publish an sdist which means users have to build from source when
then install mthree. By building wheels we ship precompiled binaries
that users can just install. This will build x86_64 on linux,
arm64 and x86_64 on MacOS, and amd64 and for windows to start. We
can expand the supported architecture set later.