### PR TITLE
[WIP] Add balanced calibrations

### DIFF
--- a/mthree/mitigation.py
+++ b/mthree/mitigation.py
@@ -335,8 +335,8 @@ class M3Mitigation():
                 if cal[0, 1] >= cal[0, 0]:
                     bad_list.append(qubits[jj])
 
-            for idx, qubit in enumerate(qubits):
-                self.single_qubit_cals[qubit] = cals[idx]
+            for idx, cal in enumerate(cals):
+                self.single_qubit_cals[qubits[idx]] = cal
 
         if any(bad_list):
             raise M3Error('Faulty qubits detected: {}'.format(bad_list))

--- a/mthree/mitigation.py
+++ b/mthree/mitigation.py
@@ -63,7 +63,7 @@ def _balanced_cal_strings(num_qubits):
         list: List of strings for balanced calibration circuits.
     """
     strings = []
-    for rep in range(1,num_qubits+1):
+    for rep in range(1, num_qubits+1):
         str1 = ''
         str2 = ''
         for jj in range(int(np.ceil(num_qubits / rep))):

--- a/mthree/mitigation.py
+++ b/mthree/mitigation.py
@@ -253,7 +253,7 @@ class M3Mitigation():
         elif method == 'balanced':
             cal_strings = _balanced_cal_strings(num_cal_qubits)
             circs = _balanced_cal_circuits(cal_strings)
-            trans_qcs = transpile(circs, self.system
+            trans_qcs = transpile(circs, self.system,
                                   initial_layout=qubits, optimization_level=0)
             job = self.system.run(trans_qcs, shots=self.cal_shots, rep_delay=self.rep_delay)
         # Indeopendent

--- a/mthree/mitigation.py
+++ b/mthree/mitigation.py
@@ -9,7 +9,7 @@
 # Any modifications or derivative works of this code must retain this
 # copyright notice, and modified files need to carry a notice indicating
 # that they have been altered from the originals.
-# pylint: disable=no-name-in-module
+# pylint: disable=no-name-in-module, invalid-name
 """Calibration data"""
 
 import warnings
@@ -55,10 +55,10 @@ def _marg_meas_states(num_qubits):
 
 def _balanced_cal_strings(num_qubits):
     """Compute the 2*num_qubits strings for balanced calibration.
-    
+
     Parameters:
         num_qubits (int): Number of qubits to be measured.
-        
+
     Returns:
         list: List of strings for balanced calibration circuits.
     """
@@ -315,7 +315,7 @@ class M3Mitigation():
                 target = cal_strings[idx][::-1]
                 good_prep = np.zeros(N,dtype=float)
                 denom = shots * N
-                
+
                 for key, val in count.items():
                     key = key[::-1]
                     for kk in range(N):

--- a/mthree/mitigation.py
+++ b/mthree/mitigation.py
@@ -308,7 +308,7 @@ class M3Mitigation():
 
         # balanced calibration
         else:
-            cals = [np.zeros((2,2), dtype=float) for kk in range(num_cal_qubits)]
+            cals = [np.zeros((2, 2), dtype=float) for kk in range(num_cal_qubits)]
 
             for idx, count in enumerate(counts):
 
@@ -324,15 +324,15 @@ class M3Mitigation():
 
                 for kk, cal in enumerate(cals):
                     if target[kk] == '0':
-                        cal[0,0] += good_prep[kk] / denom
+                        cal[0, 0] += good_prep[kk] / denom
                     else:
-                        cal[1,1] += good_prep[kk] / denom
+                        cal[1, 1] += good_prep[kk] / denom
 
             for jj, cal in enumerate(cals):
-                cal[1,0] = 1.0 - cal[0,0]
-                cal[0,1] = 1.0 - cal[1,1]
+                cal[1, 0] = 1.0 - cal[0, 0]
+                cal[0, 1] = 1.0 - cal[1, 1]
 
-                if cal[0,1] >= cal[0,0]:
+                if cal[0, 1] >= cal[0, 0]:
                     bad_list.append(qubits[jj])
 
             for idx, qubit in enumerate(qubits):

--- a/mthree/mitigation.py
+++ b/mthree/mitigation.py
@@ -308,13 +308,13 @@ class M3Mitigation():
 
         # balanced calibration
         else:
-            cals = [np.zeros((2,2), dtype=float) for kk in range(N)]
+            cals = [np.zeros((2,2), dtype=float) for kk in range(num_cal_qubits)]
 
             for idx, count in enumerate(counts):
 
                 target = cal_strings[idx][::-1]
-                good_prep = np.zeros(N,dtype=float)
-                denom = shots * N
+                good_prep = np.zeros(num_cal_qubits, dtype=float)
+                denom = shots * num_cal_qubits
 
                 for key, val in count.items():
                     key = key[::-1]

--- a/mthree/mitigation.py
+++ b/mthree/mitigation.py
@@ -273,12 +273,12 @@ class M3Mitigation():
                 self.single_qubit_cals[qubit] = np.zeros((2, 2), dtype=float)
                 # Counts 0 has all P00, P10 data, so do that here
                 prep0_counts = counts[2*idx]
-                P10 = prep0_counts.get('1', 0) / shots
+                P10 = prep0_counts.get('1', 0) / self.cal_shots
                 P00 = 1-P10
                 self.single_qubit_cals[qubit][:, 0] = [P00, P10]
                 # plus 1 here since zeros data at pos=0
                 prep1_counts = counts[2*idx+1]
-                P01 = prep1_counts.get('0', 0) / shots
+                P01 = prep1_counts.get('0', 0) / self.cal_shots
                 P11 = 1-P01
                 self.single_qubit_cals[qubit][:, 1] = [P01, P11]
                 if P01 >= P00:
@@ -293,14 +293,14 @@ class M3Mitigation():
                 for key, val in prep0_counts.items():
                     if key[index] == '0':
                         count_vals += val
-                P00 = count_vals / shots
+                P00 = count_vals / self.cal_shots
                 P10 = 1-P00
                 self.single_qubit_cals[qubit][:, 0] = [P00, P10]
                 count_vals = 0
                 for key, val in prep1_counts.items():
                     if key[index] == '1':
                         count_vals += val
-                P11 = count_vals / shots
+                P11 = count_vals / self.cal_shots
                 P01 = 1-P11
                 self.single_qubit_cals[qubit][:, 1] = [P01, P11]
                 if P01 >= P00:
@@ -314,7 +314,7 @@ class M3Mitigation():
 
                 target = cal_strings[idx][::-1]
                 good_prep = np.zeros(num_cal_qubits, dtype=float)
-                denom = shots * num_cal_qubits
+                denom = self.cal_shots * num_cal_qubits
 
                 for key, val in count.items():
                     key = key[::-1]
@@ -328,12 +328,12 @@ class M3Mitigation():
                     else:
                         cal[1,1] += good_prep[kk] / denom
 
-                for jj, cal in enumerate(cals):
-                    cal[1,0] = 1.0 - cal[0,0]
-                    cal[0,1] = 1.0 - cal[1,1]
+            for jj, cal in enumerate(cals):
+                cal[1,0] = 1.0 - cal[0,0]
+                cal[0,1] = 1.0 - cal[1,1]
 
-                    if cal[0,1] >= cal[0,0]:
-                        bad_list.append(qubits[jj])
+                if cal[0,1] >= cal[0,0]:
+                    bad_list.append(qubits[jj])
 
             for idx, qubit in enumerate(qubits):
                 self.single_qubit_cals[qubit] = cals[idx]

--- a/mthree/mitigation.py
+++ b/mthree/mitigation.py
@@ -318,7 +318,7 @@ class M3Mitigation():
 
                 for key, val in count.items():
                     key = key[::-1]
-                    for kk in range(N):
+                    for kk in range(num_cal_qubits):
                         if key[kk] == target[kk]:
                             good_prep[kk] += val
 


### PR DESCRIPTION
In speaking with @jaygambetta we are left unsatisfied with the correlation sensitive marginal calibrations using |000...> and |1111...> states that Qiskit uses, and that are mentioned in the CTMP paper.  To this end, this PR is creating a "balanced" calibration routine of 2N circuits (of which the marginal cal states are a subset) that balances the possible correlation sensitivity.  In the limit of no correlations, all of the M3 cals should be the same up to shot noise.

In practice we are seeing more state-prep errors that appear as correlated errors than we are actual correlated errors.  As evident by the dependence on `rep_delay`, but it is good to have a method like this that does use multiple measurements, but is not biased to a single cal basis direction.