### PR TITLE
Only run wheel jobs in ci on release and publish to pypi

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,8 @@
 name: Release Artifacts
 on:
   push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
+    tags:
+      - '*'
 jobs:
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
@@ -31,3 +30,31 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./wheelhouse/*.whl
+      - name: Publish to PyPi
+        env:
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          TWINE_USERNAME: nonhermitian
+        run: twine upload ./wheelhouse/*whl
+  sdist-build:
+    name: Build and Publish Release Artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.9'
+      - name: Install Deps
+        run: pip install -U twine cython numpy
+      - name: Build Artifacts
+        run: |
+          python setup.py sdist
+        shell: bash
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./dist/mthree*
+      - name: Publish to PyPi
+        env:
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          TWINE_USERNAME: nonhermitian
+        run: twine upload dist/mthree*


### PR DESCRIPTION
In #18 the PR was setup for interactive debugging and had removed the
sdist job, the upload to pypi and was also setup to run on every commit
so that I could debug issues. However, the intent of these jobs is to
only run at release for publishing wheels to pypi. This commit fixes the
definition so they only run on release and upload to pypi.