### PR TITLE
Install twine in CI release jobs.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.7'
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.1.1
         env:
@@ -53,6 +57,9 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./dist/mthree*
+      - name: Install twine
+        run: |
+          python -m pip install twine
       - name: Publish to PyPi
         env:
           TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}


### PR DESCRIPTION
In the recently configured cibuildwheel release jobs the last step is
uploading the built wheel files to pypi using twine. However, we
neglected to install twine prior to running it, resulting in an error.
This commit fixes that oversight and adds a step to install twine before
we upload.