### PR TITLE
explicitly set encoding in open()

### DIFF
--- a/mthree/mitigation.py
+++ b/mthree/mitigation.py
@@ -201,7 +201,7 @@ class M3Mitigation():
         self._grab_additional_cals(qubits, shots=shots,  method=method,
                                    rep_delay=rep_delay)
         if cals_file:
-            with open(cals_file, 'wb', encoding='utf-8') as fd:
+            with open(cals_file, 'wb') as fd:
                 fd.write(orjson.dumps(self.single_qubit_cals,
                                       option=orjson.OPT_SERIALIZE_NUMPY))
 

--- a/mthree/mitigation.py
+++ b/mthree/mitigation.py
@@ -201,7 +201,7 @@ class M3Mitigation():
         self._grab_additional_cals(qubits, shots=shots,  method=method,
                                    rep_delay=rep_delay)
         if cals_file:
-            with open(cals_file, 'wb') as fd:
+            with open(cals_file, 'wb', encoding='utf-8') as fd:
                 fd.write(orjson.dumps(self.single_qubit_cals,
                                       option=orjson.OPT_SERIALIZE_NUMPY))
 
@@ -211,7 +211,7 @@ class M3Mitigation():
             cals_file (str): A string path to the saved counts file from an
                              earlier run.
         """
-        with open(cals_file, 'r') as fd:
+        with open(cals_file, 'r', encoding='utf-8') as fd:
             self.single_qubit_cals = [np.asarray(cal) if cal else None
                                       for cal in orjson.loads(fd.read())]
 

--- a/mthree/test/test_extra_cals.py
+++ b/mthree/test/test_extra_cals.py
@@ -71,7 +71,7 @@ def test_save_cals(tmp_path):
     cal_file = tmp_path / "cal.json"
     mit = mthree.M3Mitigation(backend)
     mit.cals_from_system(cals_file=cal_file)
-    with open(cal_file, 'r') as fd:
+    with open(cal_file, 'r', encoding='utf-8') as fd:
         cals = np.array(orjson.loads(fd.read()))
     assert np.array_equal(mit.single_qubit_cals, cals)
 


### PR DESCRIPTION
It seems the pylint now complains about using `open` with no explicit encoding.  This sets it to `utf-8`