### PR TITLE
Pin version of ipykernel

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,10 +2,11 @@ qiskit>=0.24
 pytest
 pylint
 pycodestyle
-Sphinx==3.5.4
+Sphinx<4
 qiskit_sphinx_theme
 matplotlib
 pylatexenc
 jupyter-sphinx
 nbsphinx
 psutil
+ipykernel<6


### PR DESCRIPTION
`ipykernel>=6` is causing double images to appear in the documentation whenever the Matplotlib inline functionality is used.  This pins the `ipykernel` version to get around this issue until they have a solution.
