### PR TITLE
Add mitigation overhead to quasi collection

### DIFF
--- a/mthree/classes.py
+++ b/mthree/classes.py
@@ -244,7 +244,6 @@ class QuasiCollection(list):
         return ProbCollection([item.nearest_probability_distribution() for item in self])
 
 
-
 class ProbCollection(list):
     """A list subclass that makes handling multiple probability-distributions easier.
     """

--- a/mthree/classes.py
+++ b/mthree/classes.py
@@ -176,6 +176,15 @@ class QuasiCollection(list):
                 raise TypeError('QuasiCollection requires QuasiDistribution instances.')
         super().__init__(data)
 
+    @property
+    def mitigation_overhead(self):
+        """Mitigation overhead over entire collection.
+
+        Returns:
+            ndarray: Array of mitigation overhead values.
+        """
+        return np.array([item.mitigation_overhead for item in self], dtype=float)
+
     def expval(self, exp_ops=''):
         """Expectation value over entire collection.
 
@@ -233,6 +242,7 @@ class QuasiCollection(list):
             ProbCollection: Collection of ProbDistributions.
         """
         return ProbCollection([item.nearest_probability_distribution() for item in self])
+
 
 
 class ProbCollection(list):

--- a/mthree/test/test_collections.py
+++ b/mthree/test/test_collections.py
@@ -36,5 +36,5 @@ def test_mit_overhead():
     mit_counts = mit.apply_correction(raw_counts, qubits=range(5),
                                       return_mitigation_overhead=True)
 
-    ind_overheads = np.asarray([cnt.mitigation_overhead for mit in mit_counts])
+    ind_overheads = np.asarray([cnt.mitigation_overhead for cnt in mit_counts])
     assert np.allclose(mit_counts.mitigation_overhead, ind_overheads)

--- a/mthree/test/test_collections.py
+++ b/mthree/test/test_collections.py
@@ -1,0 +1,40 @@
+# This code is part of Mthree.
+#
+# (C) Copyright IBM 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+# pylint: disable=no-name-in-module
+
+"""Test collection classes"""
+import numpy as np
+from qiskit import QuantumCircuit, execute
+from qiskit.test.mock import FakeAthens
+import mthree
+
+
+def test_mit_overhead():
+    """Test if mitigation overhead over collection is same as loop
+    """
+    backend = FakeAthens()
+    qc = QuantumCircuit(5)
+    qc.h(2)
+    qc.cx(2, 1)
+    qc.cx(2, 3)
+    qc.cx(1, 0)
+    qc.cx(3, 4)
+    qc.measure_all()
+
+    raw_counts = execute([qc]*10, backend).result().get_counts()
+    mit = mthree.M3Mitigation(backend)
+    mit.cals_from_system()
+    mit_counts = mit.apply_correction(raw_counts, qubits=range(5),
+                                      return_mitigation_overhead=True)
+
+    ind_overheads = np.asarray([cnt.mitigation_overhead for mit in mit_counts])
+    assert np.allclose(mit_counts.mitigation_overhead, ind_overheads)


### PR DESCRIPTION
Adds the ability to compute the mitigation overhead for a entire collection of quasis from the collection object.

closes #37 