### PR TITLE
More collections stuff

### DIFF
--- a/docs/collections.rst
+++ b/docs/collections.rst
@@ -26,7 +26,7 @@ When you mitigate over multiple circuits the return object is a :class:`mthree.c
     mit = mthree.M3Mitigation(backend)
     mit.cals_from_system(range(6))
 
-    trans_qc = transpile([qc, backend)
+    trans_qc = transpile([qc]*10, backend)
     raw_counts = backend.run(trans_qc, shots=4000).result().get_counts()
 
     quasis = mit.apply_correction(raw_counts, range(6), return_mitigation_overhead=True)

--- a/docs/collections.rst
+++ b/docs/collections.rst
@@ -1,0 +1,47 @@
+.. _collections:
+
+##############################
+Using Distribution Collections
+##############################
+
+When you mitigate over multiple circuits the return object is a :class:`mthree.classes.QuasiCollection`
+
+.. jupyter-execute::
+
+    from qiskit import *
+    from qiskit.test.mock.backends import FakeCasablanca
+    import mthree
+
+    qc = QuantumCircuit(6)
+    qc.reset(range(6))
+    qc.h(3)
+    qc.cx(3,1)
+    qc.cx(3,5)
+    qc.cx(1,0)
+    qc.cx(5,4)
+    qc.cx(1,2)
+    qc.measure_all()
+
+    backend = FakeCasablanca()
+    mit = mthree.M3Mitigation(backend)
+    mit.cals_from_system(range(6))
+
+    trans_qc = transpile([qc, backend)
+    raw_counts = backend.run(trans_qc, shots=4000).result().get_counts()
+
+    quasis = mit.apply_correction(raw_counts, range(6), return_mitigation_overhead=True)
+    type(quasis)
+
+``QuasiCollection`` objects allow one to work with multiple distributions in the same manner as
+a single one.  E.g. we can get the mitigation overhead of the whole collection
+
+.. jupyter-execute::
+
+    quasis.mitigation_overhead
+
+or compute expectation values and standard deviations over the full set:
+
+.. jupyter-execute::
+
+    quasis.expval_and_stddev('IZIZIZ')
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,9 +36,10 @@ residual (GMRES) or biconjugate gradient stabilized (BiCGSTAB) methods.
  
     Basic usage <basic>
     Transpiled circuits <transpiled>
-    Saving and loading calibrations <cal_io>
     Error analysis <error>
     Obtaining probabilities <probs>
+    Using Collections <collections>
+    Saving and loading calibrations <cal_io>
     Advanced usage <advanced>
 
 .. toctree::

--- a/mthree/classes.py
+++ b/mthree/classes.py
@@ -177,6 +177,15 @@ class QuasiCollection(list):
         super().__init__(data)
 
     @property
+    def shots(self):
+        """Number of shots taken over collection.
+
+        Returns:
+            ndarray: Array of shots values.
+        """
+        return np.array([item.shots for item in self], dtype=int)
+
+    @property
     def mitigation_overhead(self):
         """Mitigation overhead over entire collection.
 
@@ -260,6 +269,15 @@ class ProbCollection(list):
             if not isinstance(dd, ProbDistribution):
                 raise TypeError('ProbCollection requires ProbDistribution instances.')
         super().__init__(data)
+
+    @property
+    def shots(self):
+        """Number of shots taken over collection.
+
+        Returns:
+            ndarray: Array of shots values.
+        """
+        return np.array([item.shots for item in self], dtype=int)
 
     def expval(self, exp_ops=''):
         """Expectation value over entire collection.

--- a/mthree/mitigation.py
+++ b/mthree/mitigation.py
@@ -378,12 +378,24 @@ class M3Mitigation():
         if not given_list:
             counts = [counts]
 
-        quasi_out = [self._apply_correction(cnts, qubits=qubits,
-                                            distance=distance,
-                                            method=method,
-                                            max_iter=max_iter, tol=tol,
-                                            return_mitigation_overhead=return_mitigation_overhead,
-                                            details=details) for cnts in counts]
+        if not any(isinstance(qq, (list, tuple, np.ndarray)) for qq in qubits):
+            qubits = [qubits]
+
+        if len(qubits) != len(counts):
+            raise M3Error('Length of counts does not match length of qubits.')
+
+        quasi_out = []
+
+        for idx, cnts in enumerate(counts):
+            
+            quasi_out.append(
+                self._apply_correction(cnts, qubits=qubits[idx],
+                                       distance=distance,
+                                       method=method,
+                                       max_iter=max_iter, tol=tol,
+                                       return_mitigation_overhead=return_mitigation_overhead,
+                                       details=details)
+                            )
 
         if not given_list:
             return quasi_out[0]

--- a/mthree/mitigation.py
+++ b/mthree/mitigation.py
@@ -387,7 +387,7 @@ class M3Mitigation():
         quasi_out = []
 
         for idx, cnts in enumerate(counts):
-            
+
             quasi_out.append(
                 self._apply_correction(cnts, qubits=qubits[idx],
                                        distance=distance,

--- a/mthree/mitigation.py
+++ b/mthree/mitigation.py
@@ -379,7 +379,7 @@ class M3Mitigation():
             counts = [counts]
 
         if not any(isinstance(qq, (list, tuple, np.ndarray)) for qq in qubits):
-            qubits = [qubits]
+            qubits = [qubits]*len(counts)
 
         if len(qubits) != len(counts):
             raise M3Error('Length of counts does not match length of qubits.')

--- a/mthree/test/test_collections.py
+++ b/mthree/test/test_collections.py
@@ -39,6 +39,7 @@ def test_mit_overhead():
     ind_overheads = np.asarray([cnt.mitigation_overhead for cnt in mit_counts])
     assert np.allclose(mit_counts.mitigation_overhead, ind_overheads)
 
+
 def test_shots():
     """Test if shots works over collections
     """

--- a/mthree/test/test_collections.py
+++ b/mthree/test/test_collections.py
@@ -38,3 +38,24 @@ def test_mit_overhead():
 
     ind_overheads = np.asarray([cnt.mitigation_overhead for cnt in mit_counts])
     assert np.allclose(mit_counts.mitigation_overhead, ind_overheads)
+
+def test_shots():
+    """Test if shots works over collections
+    """
+    backend = FakeAthens()
+    qc = QuantumCircuit(5)
+    qc.h(2)
+    qc.cx(2, 1)
+    qc.cx(2, 3)
+    qc.cx(1, 0)
+    qc.cx(3, 4)
+    qc.measure_all()
+
+    raw_counts = execute([qc]*10, backend).result().get_counts()
+    mit = mthree.M3Mitigation(backend)
+    mit.cals_from_system()
+    mit_counts = mit.apply_correction(raw_counts, qubits=range(5),
+                                      return_mitigation_overhead=True)
+
+    assert np.allclose(mit_counts.nearest_probability_distribution().shots,
+                       mit_counts.shots)

--- a/mthree/test/test_collections.py
+++ b/mthree/test/test_collections.py
@@ -51,7 +51,7 @@ def test_shots():
     qc.cx(3, 4)
     qc.measure_all()
 
-    raw_counts = execute([qc]*10, backend).result().get_counts()
+    raw_counts = execute([qc]*10, backend, shots=4321).result().get_counts()
     mit = mthree.M3Mitigation(backend)
     mit.cals_from_system()
     mit_counts = mit.apply_correction(raw_counts, qubits=range(5),
@@ -59,3 +59,5 @@ def test_shots():
 
     assert np.allclose(mit_counts.nearest_probability_distribution().shots,
                        mit_counts.shots)
+
+    assert np.all(mit_counts.shots == 4321)


### PR DESCRIPTION
- Adds the ability to get `mitigation_overhead` and `shots` from `Collections`.

- Adds the ability to pass a nested list for `qubits` in `apply_correction`.  This is useful for cases where the trnaspiler changes qubits on a per circuit basis.

- Adds documentation for working with `Collections`.