### PR TITLE
Check if compiled with omp from about function

### DIFF
--- a/mthree/__init__.py
+++ b/mthree/__init__.py
@@ -23,8 +23,10 @@ Mitigation classes
 
 try:
     from .version import version as __version__
+    from .version import openmp
 except ImportError:
     __version__ = '0.0.0'
+    openmp = False
 
 from .mitigation import M3Mitigation
 
@@ -35,5 +37,7 @@ def about():
     print('='*80)
     print('# Matrix-free Measurement Mitigation (M3) version {}'.format(__version__))
     print('# (C) Copyright IBM 2021.')
-    print('# Paul D. Nation, Hwajung Kang, Neereja Sundaresan, and Jay Gambetta')
+    print('# Paul Nation, Hwajung Kang, Neereja Sundaresan')
+    print('# Jay Gambetta, and Matthew Treinish.')
+    print('# Compiled with OpenMP: {}'.format(openmp))
     print('='*80)

--- a/setup.py
+++ b/setup.py
@@ -122,7 +122,7 @@ def write_version_py(filename='mthree/version.py'):
 # pylint: disable=missing-module-docstring
 short_version = '%(version)s'
 version = '%(fullversion)s'
-openmp =  %(with_omp)s
+openmp = %(with_omp)s
 """
     a = open(filename, 'w')
     try:

--- a/setup.py
+++ b/setup.py
@@ -59,11 +59,13 @@ CYTHON_SOURCE_DIRS = ['mthree']*7 + \
 # Add openmp flags
 OPTIONAL_FLAGS = []
 OPTIONAL_ARGS = []
+WITH_OMP = False
 for _arg in sys.argv:
     if _arg.startswith("--with-"):
         _options = _arg.split("--with-")[1].split(",")
         sys.argv.remove(_arg)
         if "openmp" in _options or os.getenv("MTHREE_OPENMP", False):
+            WITH_OMP = True
             if sys.platform == 'win32':
                 OPTIONAL_FLAGS = ['/openmp']
             else:
@@ -120,12 +122,12 @@ def write_version_py(filename='mthree/version.py'):
 # pylint: disable=missing-module-docstring
 short_version = '%(version)s'
 version = '%(fullversion)s'
-release = %(isrelease)s
+openmp =  %(with_omp)s
 """
     a = open(filename, 'w')
     try:
-        a.write(cnt % {'version': VERSION, 'fullversion':
-                       FULLVERSION, 'isrelease': str(ISRELEASED)})
+        a.write(cnt % {'version': VERSION, 'fullversion':FULLVERSION,
+                       'with_omp': str(WITH_OMP)})
     finally:
         a.close()
 


### PR DESCRIPTION
Allow users to check if M3 was compiled with the `openmp` flag.