### PR TITLE
bump version requirements for Qiskit

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-qiskit>=0.24
+qiskit>=0.28
 pytest
 pylint
 pycodestyle

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy>=1.17
 scipy>=1.3
 cython>=0.29
-qiskit-terra>=0.16
-qiskit-ibmq-provider>=0.11
+qiskit-terra>=0.18
+qiskit-ibmq-provider>=0.15
 psutil
 orjson>=3.0.0


### PR DESCRIPTION
closes #53 

Bumps all Qiskit requirements to support Qiskit 0.18 that is needed for using `backend.run()` in fake backends, and probably other places.