### PR TITLE
Update default calibration shots to min 10k or max_shots

### DIFF
--- a/mthree/mitigation.py
+++ b/mthree/mitigation.py
@@ -174,13 +174,13 @@ class M3Mitigation():
         cals = self._form_cals(qubits)
         return sdd_check(counts, cals, num_bits, distance)
 
-    def tensored_cals_from_system(self, qubits=None, shots=8192,  method='balanced',
+    def tensored_cals_from_system(self, qubits=None, shots=None,  method='balanced',
                                   rep_delay=None, cals_file=None):
         """Grab calibration data from system.
 
         Parameters:
             qubits (array_like): Qubits over which to correct calibration data. Default is all.
-            shots (int): Number of shots per circuit. Default is 8192.
+            shots (int): Number of shots per circuit. Default is min(1e4, max_shots).
             method (str): Type of calibration, 'balanced' (default), 'independent', or 'marginal'.
             rep_delay (float): Delay between circuits on IBM Quantum backends.
             cals_file (str): Output path to write JSON calibration data to.
@@ -190,13 +190,13 @@ class M3Mitigation():
                               rep_delay=rep_delay,
                               cals_file=cals_file)
 
-    def cals_from_system(self, qubits=None, shots=8192, method='balanced',
+    def cals_from_system(self, qubits=None, shots=None, method='balanced',
                          initial_reset=False, rep_delay=None, cals_file=None):
         """Grab calibration data from system.
 
         Parameters:
             qubits (array_like): Qubits over which to correct calibration data. Default is all.
-            shots (int): Number of shots per circuit. Default is 8192.
+            shots (int): Number of shots per circuit. min(1e4, max_shots).
             method (str): Type of calibration, 'balanced' (default), 'independent', or 'marginal'.
             initial_reset (bool): Use resets at beginning of calibration circuits, default=False.
             rep_delay (float): Delay between circuits on IBM Quantum backends.
@@ -232,13 +232,13 @@ class M3Mitigation():
         warnings.warn("This method is deprecated, use 'cals_from_file' instead.")
         self.cals_from_file(cals_file)
 
-    def _grab_additional_cals(self, qubits, shots=8192, method='balanced', rep_delay=None,
+    def _grab_additional_cals(self, qubits, shots=None, method='balanced', rep_delay=None,
                               initial_reset=False):
         """Grab missing calibration data from backend.
 
         Parameters:
             qubits (array_like): List of measured qubits.
-            shots (int): Number of shots to take.
+            shots (int): Number of shots to take, min(1e4, max_shots).
             method (str): Type of calibration, 'balanced' (default), 'independent', or 'marginal'.
             rep_delay (float): Delay between circuits on IBM Quantum backends.
             initial_reset (bool): Use resets at beginning of calibration circuits, default=False.
@@ -252,6 +252,8 @@ class M3Mitigation():
         if self.single_qubit_cals is None:
             self.single_qubit_cals = [None]*self.num_qubits
         if self.cal_shots is None:
+            if shots is None:
+                shots = min(self.system.configuration().max_shots, 10000)
             self.cal_shots = shots
         if self.rep_delay is None:
             self.rep_delay = rep_delay

--- a/mthree/test/test_default_shots.py
+++ b/mthree/test/test_default_shots.py
@@ -1,0 +1,64 @@
+# This code is part of Mthree.
+#
+# (C) Copyright IBM 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+# pylint: disable=no-name-in-module
+
+"""Test matrix elements"""
+from qiskit import QuantumCircuit, execute
+from qiskit.test.mock import FakeAthens
+import mthree
+
+
+LOW_SHOTS = 543
+HIGH_SHOTS = 100000
+
+def test_athens_mod_shots1():
+    """Check that default shots works properly for low settings"""
+    backend = FakeAthens()
+
+    qc = QuantumCircuit(5)
+    qc.h(2)
+    qc.cx(2, 1)
+    qc.cx(2, 3)
+    qc.cx(1, 0)
+    qc.cx(3, 4)
+    qc.measure_all()
+
+    backend._configuration.max_shots = LOW_SHOTS
+
+    raw_counts = execute(qc, backend).result().get_counts()
+    mit = mthree.M3Mitigation(backend)
+    mit.cals_from_system()
+    mit_counts = mit.apply_correction(raw_counts, qubits=range(5))
+
+    assert mit_counts.shots == LOW_SHOTS
+
+def test_athens_mod_shots2():
+    """Check that default shots works properly for high settings"""
+    backend = FakeAthens()
+
+    qc = QuantumCircuit(5)
+    qc.h(2)
+    qc.cx(2, 1)
+    qc.cx(2, 3)
+    qc.cx(1, 0)
+    qc.cx(3, 4)
+    qc.measure_all()
+
+    backend._configuration.max_shots = HIGH_SHOTS
+
+    raw_counts = execute(qc, backend).result().get_counts()
+    mit = mthree.M3Mitigation(backend)
+    mit.cals_from_system()
+    mit_counts = mit.apply_correction(raw_counts, qubits=range(5))
+
+    assert mit_counts.shots == 10000
+

--- a/mthree/test/test_default_shots.py
+++ b/mthree/test/test_default_shots.py
@@ -16,9 +16,9 @@ from qiskit import QuantumCircuit, execute
 from qiskit.test.mock import FakeAthens
 import mthree
 
-
 LOW_SHOTS = 543
 HIGH_SHOTS = 100000
+
 
 def test_athens_mod_shots1():
     """Check that default shots works properly for low settings"""
@@ -40,6 +40,7 @@ def test_athens_mod_shots1():
     mit_counts = mit.apply_correction(raw_counts, qubits=range(5))
 
     assert mit_counts.shots == LOW_SHOTS
+
 
 def test_athens_mod_shots2():
     """Check that default shots works properly for high settings"""

--- a/mthree/test/test_default_shots.py
+++ b/mthree/test/test_default_shots.py
@@ -61,4 +61,3 @@ def test_athens_mod_shots2():
     mit_counts = mit.apply_correction(raw_counts, qubits=range(5))
 
     assert mit_counts.shots == 10000
-

--- a/mthree/test/test_default_shots.py
+++ b/mthree/test/test_default_shots.py
@@ -12,7 +12,6 @@
 # pylint: disable=no-name-in-module
 
 """Test matrix elements"""
-from qiskit import QuantumCircuit, execute
 from qiskit.test.mock import FakeAthens
 import mthree
 

--- a/mthree/test/test_default_shots.py
+++ b/mthree/test/test_default_shots.py
@@ -23,42 +23,18 @@ HIGH_SHOTS = 100000
 def test_athens_mod_shots1():
     """Check that default shots works properly for low settings"""
     backend = FakeAthens()
-
-    qc = QuantumCircuit(5)
-    qc.h(2)
-    qc.cx(2, 1)
-    qc.cx(2, 3)
-    qc.cx(1, 0)
-    qc.cx(3, 4)
-    qc.measure_all()
-
     backend._configuration.max_shots = LOW_SHOTS
-
-    raw_counts = execute(qc, backend).result().get_counts()
     mit = mthree.M3Mitigation(backend)
     mit.cals_from_system()
-    mit_counts = mit.apply_correction(raw_counts, qubits=range(5))
 
-    assert mit_counts.shots == LOW_SHOTS
+    assert mit.cal_shots == LOW_SHOTS
 
 
 def test_athens_mod_shots2():
     """Check that default shots works properly for high settings"""
     backend = FakeAthens()
-
-    qc = QuantumCircuit(5)
-    qc.h(2)
-    qc.cx(2, 1)
-    qc.cx(2, 3)
-    qc.cx(1, 0)
-    qc.cx(3, 4)
-    qc.measure_all()
-
     backend._configuration.max_shots = HIGH_SHOTS
-
-    raw_counts = execute(qc, backend).result().get_counts()
     mit = mthree.M3Mitigation(backend)
     mit.cals_from_system()
-    mit_counts = mit.apply_correction(raw_counts, qubits=range(5))
 
-    assert mit_counts.shots == 10000
+    assert mit.cal_shots == 10000


### PR DESCRIPTION
Update the default shots to `min(10000, backend.configuration().max_shots)`.