### PR TITLE
Check for empty counts input

### DIFF
--- a/mthree/mitigation.py
+++ b/mthree/mitigation.py
@@ -399,6 +399,8 @@ class M3Mitigation():
         Raises:
             M3Error: Bitstring length does not match number of qubits given.
         """
+        if not any(counts):
+            raise M3Error('Input counts is any empty dict.')
         given_list = False
         if isinstance(counts, (list, np.ndarray)):
             given_list = True

--- a/mthree/mitigation.py
+++ b/mthree/mitigation.py
@@ -399,7 +399,7 @@ class M3Mitigation():
         Raises:
             M3Error: Bitstring length does not match number of qubits given.
         """
-        if not len(counts):
+        if len(counts) == 0:
             raise M3Error('Input counts is any empty dict.')
         given_list = False
         if isinstance(counts, (list, np.ndarray)):

--- a/mthree/mitigation.py
+++ b/mthree/mitigation.py
@@ -399,7 +399,7 @@ class M3Mitigation():
         Raises:
             M3Error: Bitstring length does not match number of qubits given.
         """
-        if not any(counts):
+        if not len(counts):
             raise M3Error('Input counts is any empty dict.')
         given_list = False
         if isinstance(counts, (list, np.ndarray)):


### PR DESCRIPTION
If you pass an empty dict then the error msg is very cryptic.  So here we check for it and raise an `M3Error`.