### PR TITLE
Calibrations can be saved at any time

### DIFF
--- a/docs/cal_io.rst
+++ b/docs/cal_io.rst
@@ -22,11 +22,6 @@ or,
 
 .. jupyter-execute::
 
-    from qiskit.test.mock.backends import FakeCasablanca
-    import mthree
-
-    backend = FakeCasablanca()
-
     mit = mthree.M3Mitigation(backend)
     mit.cals_from_system([1, 3, 5])
     mit.cals_to_file('my_cals.json')

--- a/docs/cal_io.rst
+++ b/docs/cal_io.rst
@@ -18,6 +18,19 @@ Let us generate some calibration data and save it.
     mit.cals_from_system([1, 3, 5], cals_file='my_cals.json')
     mit.single_qubit_cals
 
+or,
+
+.. jupyter-execute::
+
+    from qiskit.test.mock.backends import FakeCasablanca
+    import mthree
+
+    backend = FakeCasablanca()
+
+    mit = mthree.M3Mitigation(backend)
+    mit.cals_from_system([1, 3, 5])
+    mit.cals_to_file('my_cals.json')
+
 We can then load this data at a later point in time using:
 
 

--- a/mthree/mitigation.py
+++ b/mthree/mitigation.py
@@ -229,9 +229,7 @@ class M3Mitigation():
         self._grab_additional_cals(qubits, shots=shots,  method=method,
                                    rep_delay=rep_delay, initial_reset=initial_reset)
         if cals_file:
-            with open(cals_file, 'wb') as fd:
-                fd.write(orjson.dumps(self.single_qubit_cals,
-                                      option=orjson.OPT_SERIALIZE_NUMPY))
+            self.cals_to_file(cals_file)
 
     def cals_from_file(self, cals_file):
         """Generated the calibration data from a previous runs output

--- a/mthree/mitigation.py
+++ b/mthree/mitigation.py
@@ -245,6 +245,24 @@ class M3Mitigation():
             self.single_qubit_cals = [np.asarray(cal) if cal else None
                                       for cal in orjson.loads(fd.read())]
 
+    def cals_to_file(self, cals_file=None):
+        """Save calibration data to JSON file.
+
+            Parameters:
+                cals_file (str): File in which to store calibrations.
+
+            Raises:
+                M3Error: Calibration filename missing.
+                M3Error: Mitigator is not calibrated.
+        """
+        if not cals_file:
+            raise M3Error('cals_file must be explicitly set.')
+        if not self.single_qubit_cals:
+            raise M3Error('Mitigator is not calibrated.')
+        with open(cals_file, 'wb') as fd:
+            fd.write(orjson.dumps(self.single_qubit_cals,
+                                  option=orjson.OPT_SERIALIZE_NUMPY))
+
     def tensored_cals_from_file(self, cals_file):
         """Generated the tensored calibration data from a previous runs output
 

--- a/mthree/mitigation.py
+++ b/mthree/mitigation.py
@@ -236,6 +236,8 @@ class M3Mitigation():
 
             cals_file (str): A string path to the saved counts file from an
                              earlier run.
+            Raises:
+                M3Error: Calibration in progress.
         """
         if self._thread:
             raise M3Error('Calibration currently in progress.')

--- a/mthree/test/test_file_io.py
+++ b/mthree/test/test_file_io.py
@@ -48,3 +48,36 @@ def test_load_cals_from_file():
 
     mit2_counts = mit.apply_correction(raw_counts, qubits=range(5))
     assert mit2_counts is not None
+
+
+def test_load_cals_from_file2():
+    """Check the cals can be loaded from a saved file later"""
+    backend = FakeAthens()
+
+    qc = QuantumCircuit(5)
+    qc.h(2)
+    qc.cx(2, 1)
+    qc.cx(2, 3)
+    qc.cx(1, 0)
+    qc.cx(3, 4)
+    qc.measure_all()
+
+    raw_counts = execute(qc, backend).result().get_counts()
+    mit = mthree.M3Mitigation(backend)
+    mit.cals_from_system()
+    mit.cals_to_file('cals.json')
+
+    mit2 = mthree.M3Mitigation()
+    mit2.cals_from_file(cals_file='cals.json')
+
+    assert len(mit.single_qubit_cals) == len(mit2.single_qubit_cals)
+
+    # check that cals are identical
+    for idx, item in enumerate(mit.single_qubit_cals):
+        if item is None:
+            assert mit2.single_qubit_cals[idx] is None
+        else:
+            assert np.allclose(item, mit2.single_qubit_cals[idx])
+
+    mit2_counts = mit.apply_correction(raw_counts, qubits=range(5))
+    assert mit2_counts is not None


### PR DESCRIPTION
Previously one could save calibrations only when they were being generated.  Here we allow one to save the calibrations at any point in time.

fixes #69 