### PR TITLE
Adjust CI trigger to run pre-merge on all pull requests

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -1,6 +1,9 @@
 name: Linux - conda
-on: [push]
-
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
 jobs:
   build-linux:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This commit adjust the ci configuration for mapomatic to run pre-merge
on all opened PRs to the main branch. Previously it was configured to
only run on push events which would get triggered by any commit being
pushed to an upstream branch. However, this wouldn't run CI on a pull
request opened from a fork until after it was merged. By changing this
to trigger on pull requests we enable running the tests before we merge
to make sure all proposed changes don't cause a regresssion.