### PR TITLE
Fix mitigation overhead for single bitstring

### DIFF
--- a/mthree/norms.py
+++ b/mthree/norms.py
@@ -36,6 +36,10 @@ def ainv_onenorm_est_lu(A, LU=None):
     """
     dims = A.shape[0]
 
+    # If only a single bitstring then there is no overhead
+    if dims == 1:
+        return 1.0
+
     # Starting vec
     v = (1.0/dims)*np.ones(dims, dtype=float)
 
@@ -121,6 +125,10 @@ def ainv_onenorm_est_iter(M, tol=1e-5, max_iter=25):
     P = spla.LinearOperator((M.num_elems, M.num_elems), precond_matvec)
 
     dims = M.num_elems
+
+    # If only a single bitstring then there is no overhead
+    if dims == 1:
+        return 1.0
 
     # Starting vec
     v = (1.0/dims)*np.ones(dims, dtype=float)

--- a/mthree/test/test_odd_cases.py
+++ b/mthree/test/test_odd_cases.py
@@ -13,7 +13,6 @@
 
 """Test utils functions"""
 from qiskit import Aer, QuantumCircuit, transpile
-from qiskit.test.mock import FakeAthens
 import mthree
 
 

--- a/mthree/test/test_odd_cases.py
+++ b/mthree/test/test_odd_cases.py
@@ -1,0 +1,33 @@
+# This code is part of Mthree.
+#
+# (C) Copyright IBM 2021.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+# pylint: disable=no-name-in-module
+
+"""Test utils functions"""
+from qiskit import Aer, QuantumCircuit, transpile
+from qiskit.test.mock import FakeAthens
+import mthree
+
+
+def test_simulator_overhead():
+    """Verify a single bitstring from the sim works with mitigation overhead"""
+    qc = QuantumCircuit(6)
+    qc.measure_all()
+
+    backend = Aer.get_backend("statevector_simulator")
+    mit = mthree.M3Mitigation(backend)
+    mit.cals_from_system(range(6))
+
+    trans_qc = transpile(qc, backend)
+    raw_counts = backend.run(trans_qc, shots=100).result().get_counts()
+
+    quasi = mit.apply_correction(raw_counts, range(6), return_mitigation_overhead=True)
+    assert quasi.mitigation_overhead == 1.0


### PR DESCRIPTION
fixes #88 

The mitigation overhead method assumes you have at least a 2x2 matrix, and fails for a single element.  However, if there is a single element then the overhead is exactly 1.0.  Therefore we hard-code this edge case.