### PR TITLE
Fix incorect operator indexing

### DIFF
--- a/mthree/expval.pyx
+++ b/mthree/expval.pyx
@@ -67,7 +67,7 @@ def exp_val(object dist, str exp_ops='', dict dict_ops={}):
         else:
             oper_prod = 1
             for kk in range(bits_len):
-                oper_prod *= OPER_MAP[2*ops[kk] + <int>(key[bits_len-kk-1])-48]
+                oper_prod *= OPER_MAP[2*ops[kk] + <int>(key[kk])-48]
 
         exp_val += val * oper_prod
     

--- a/mthree/test/test_expvals.py
+++ b/mthree/test/test_expvals.py
@@ -27,8 +27,9 @@ def test_basic_expvals():
     # flipping one to I makes even GHZ 0.0
     assert np.allclose(exp_val({'00': 0.5, '11': 0.5}, 'IZ'), 0.0)
     assert np.allclose(exp_val({'00': 0.5, '11': 0.5}, 'ZI'), 0.0)
-    #Generic Z on PROBS
+    # Generic Z on PROBS
     assert np.allclose(exp_val(PROBS, 'ZZZZ'), 0.7554)
+
 
 def test_asym_operators():
     """Test that asym exp values work"""

--- a/mthree/test/test_expvals.py
+++ b/mthree/test/test_expvals.py
@@ -35,6 +35,7 @@ def test_asym_operators():
     """Test that asym exp values work"""
     assert np.allclose(exp_val(PROBS, '0III'), 0.5318)
     assert np.allclose(exp_val(PROBS, 'III0'), 0.5285)
+    assert np.allclose(exp_val(PROBS, '1011'), 0.0211)
 
 
 PROBS = {'1000': 0.0022,

--- a/mthree/test/test_expvals.py
+++ b/mthree/test/test_expvals.py
@@ -27,3 +27,26 @@ def test_basic_expvals():
     # flipping one to I makes even GHZ 0.0
     assert np.allclose(exp_val({'00': 0.5, '11': 0.5}, 'IZ'), 0.0)
     assert np.allclose(exp_val({'00': 0.5, '11': 0.5}, 'ZI'), 0.0)
+
+def test_asym_operators():
+    """Test that asym exp values work"""
+    assert np.allclose(exp_val(PROBS, '0III', 0.5318))
+    assert np.allclose(exp_val(PROBS, 'III0', 0.5285))
+
+PROBS = {'1000': 0.0022,
+         '1001': 0.0045,
+         '1110': 0.0081,
+         '0001': 0.0036,
+         '0010': 0.0319,
+         '0101': 0.001,
+         '1100': 0.0008,
+         '1010': 0.0009,
+         '1111': 0.3951,
+         '0011': 0.0007,
+         '0111': 0.01,
+         '0000': 0.4666,
+         '1101': 0.0355,
+         '1011': 0.0211,
+         '0110': 0.0081,
+         '0100': 0.0099
+         }

--- a/mthree/test/test_expvals.py
+++ b/mthree/test/test_expvals.py
@@ -27,7 +27,8 @@ def test_basic_expvals():
     # flipping one to I makes even GHZ 0.0
     assert np.allclose(exp_val({'00': 0.5, '11': 0.5}, 'IZ'), 0.0)
     assert np.allclose(exp_val({'00': 0.5, '11': 0.5}, 'ZI'), 0.0)
-
+    #Generic Z on PROBS
+    assert np.allclose(exp_val(PROBS, 'ZZZZ'), 0.7554)
 
 def test_asym_operators():
     """Test that asym exp values work"""

--- a/mthree/test/test_expvals.py
+++ b/mthree/test/test_expvals.py
@@ -28,10 +28,12 @@ def test_basic_expvals():
     assert np.allclose(exp_val({'00': 0.5, '11': 0.5}, 'IZ'), 0.0)
     assert np.allclose(exp_val({'00': 0.5, '11': 0.5}, 'ZI'), 0.0)
 
+
 def test_asym_operators():
     """Test that asym exp values work"""
     assert np.allclose(exp_val(PROBS, '0III'), 0.5318)
     assert np.allclose(exp_val(PROBS, 'III0'), 0.5285)
+
 
 PROBS = {'1000': 0.0022,
          '1001': 0.0045,

--- a/mthree/test/test_expvals.py
+++ b/mthree/test/test_expvals.py
@@ -30,8 +30,8 @@ def test_basic_expvals():
 
 def test_asym_operators():
     """Test that asym exp values work"""
-    assert np.allclose(exp_val(PROBS, '0III', 0.5318))
-    assert np.allclose(exp_val(PROBS, 'III0', 0.5285))
+    assert np.allclose(exp_val(PROBS, '0III'), 0.5318)
+    assert np.allclose(exp_val(PROBS, 'III0'), 0.5285)
 
 PROBS = {'1000': 0.0022,
          '1001': 0.0045,


### PR DESCRIPTION
As found via work on the sparse strings, operators were being indexed in the incorrect order (or one can also think of strings being incorrect).  This fixes that and adds a few tests for asymmetric operators that caught this.