### PR TITLE
Remove hardcoded OSX min version

### DIFF
--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -5,7 +5,8 @@ on:
   pull_request:
     branches: [main]
 jobs:
-  build-linux:
+  conda-test:
+    name: Conda tests on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       max-parallel: 5

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        os: [ubuntu-20.04, macos-11, windows-2019]
+        os: [ubuntu-20.04, macos-11]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -6,9 +6,11 @@ on:
     branches: [main]
 jobs:
   build-linux:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
     strategy:
       max-parallel: 5
+      matrix:
+        os: [ubuntu-20.04, macos-11]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -1,4 +1,4 @@
-name: Linux - conda
+name: Conda - tests
 on:
   push:
     branches: [main]

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -1,4 +1,4 @@
-name: Conda - tests
+name: Pytest
 on:
   push:
     branches: [main]

--- a/.github/workflows/python-package-conda.yml
+++ b/.github/workflows/python-package-conda.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        os: [ubuntu-20.04, macos-11]
+        os: [ubuntu-20.04, macos-11, windows-2019]
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-11]
+        os: [ubuntu-20.04, windows-2019, macos-10.15]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, windows-2019, macos-10.15]
+        os: [ubuntu-20.04, windows-2019, macos-11]
 
     steps:
       - uses: actions/checkout@v2

--- a/setup.py
+++ b/setup.py
@@ -82,12 +82,7 @@ if (sys.platform == 'win32' and os.environ.get('MSYSTEM') is None):
     COMPILER_FLAGS = ['/O3']
 # Everything else
 else:
-    COMPILER_FLAGS = ['-O3', '-ffast-math', '-std=c++17']
-    if sys.platform == 'darwin':
-        # These are needed for compiling on OSX 10.14+
-        COMPILER_FLAGS.append('-mmacosx-version-min=11')
-        LINK_FLAGS.append('-mmacosx-version-min=11')
-
+    COMPILER_FLAGS = ['-O3', '-std=c++17']
 
 EXT_MODULES = []
 # Add Cython Extensions

--- a/setup.py
+++ b/setup.py
@@ -85,8 +85,8 @@ else:
     COMPILER_FLAGS = ['-O3', '-ffast-math', '-std=c++17']
     if sys.platform == 'darwin':
         # These are needed for compiling on OSX 10.14+
-        COMPILER_FLAGS.append('-mmacosx-version-min=10.14')
-        LINK_FLAGS.append('-mmacosx-version-min=10.14')
+        COMPILER_FLAGS.append('-mmacosx-version-min=11')
+        LINK_FLAGS.append('-mmacosx-version-min=11')
 
 
 EXT_MODULES = []


### PR DESCRIPTION
Removes the hard coding for OSX min version number.  Can now set via `MACOSX_DEPLOYMENT_TARGET` as suggested by @mtreinish 