### PR TITLE
make async calibration optional

### DIFF
--- a/mthree/test/test_threading.py
+++ b/mthree/test/test_threading.py
@@ -36,5 +36,5 @@ def test_test_call_cals_twice():
     maps = final_measurement_mapping(circs)
     mit = mthree.M3Mitigation(backend)
     with pytest.raises(M3Error):
-        mit.cals_from_system(maps)
-        mit.cals_from_system(maps)
+        mit.cals_from_system(maps, async_cal=True)
+        mit.cals_from_system(maps, async_cal=True)

--- a/mthree/test/test_threading.py
+++ b/mthree/test/test_threading.py
@@ -38,3 +38,7 @@ def test_test_call_cals_twice():
     with pytest.raises(M3Error):
         mit.cals_from_system(maps, async_cal=True)
         mit.cals_from_system(maps, async_cal=True)
+
+    with pytest.raises(M3Error):
+        mit.cals_from_system(maps, async_cal=True)
+        mit.cals_from_system(maps)


### PR DESCRIPTION
The calibrations were made async as suggested in #71.  However, while this has benefits in the fairshare queuing model, it causes issues with other frameworks.  This makes async cals opt-in