### PR TITLE
Improve numpy compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "wheel", "cython>=0.29", "oldest-supported-numpy"]
+build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -18,16 +18,8 @@ import sys
 import subprocess
 import setuptools
 
-try:
-    import numpy as np
-except ImportError:
-    subprocess.call([sys.executable, '-m', 'pip', 'install', 'numpy>=1.17'])
-    import numpy as np
-try:
-    from Cython.Build import cythonize
-except ImportError:
-    subprocess.call([sys.executable, '-m', 'pip', 'install', 'cython>=0.29'])
-    from Cython.Build import cythonize
+import numpy as np
+from Cython.Build import cythonize
 
 
 MAJOR = 0


### PR DESCRIPTION
This commit updates the build system to fix compatibility with numpy
versions. When we build wheels we should build against the oldest
version of numpy as possible. This ensures that when we publish wheels
to pypi the binaries will work with any version of numpy. Right now we
build against the latest version of numpy which restricts users to run
with a more recent version of numpy as it's built against a newer abi
version. To accomplish this a pyproject.toml is used, this makes it very
easy to list specific build system requirements and provides more
flexibility than calling pip during setup.py. This does require pip (or
any other install tool) to be compatible with PEP518 to be usable, but
that was initially included in pip 10, but it wasn't the best supported
until pip 19, which are both over 3 years old at this point and most
users building from source should hopefully have updated to at least
that version of pip.