### PR TITLE
Fix bug computing expvals for statevector probabilities

### DIFF
--- a/mthree/classes.py
+++ b/mthree/classes.py
@@ -55,7 +55,7 @@ class ProbDistribution(dict):
         # _gen_call means being called from the general utils function
         if isinstance(data, Counts):
             # Convert Counts to probs
-            self.shots = int(sum(data.values()))
+            self.shots = sum(data.values())
             self.mitigation_overhead = 1
             _data = {}
             for key, val, in data.items():
@@ -63,7 +63,7 @@ class ProbDistribution(dict):
             data = _data
         else:
             if shots is None:
-                self.shots = int(sum(data.values()))
+                self.shots = sum(data.values())
                 self.mitigation_overhead = 1
                 if self.shots != 1:
                     _data = {}

--- a/mthree/test/test_utils.py
+++ b/mthree/test/test_utils.py
@@ -14,6 +14,7 @@
 """Test utils functions"""
 import numpy as np
 from qiskit import QuantumCircuit, execute
+from qiskit.quantum_info import Statevector
 from qiskit.test.mock import FakeAthens
 import mthree
 
@@ -112,3 +113,17 @@ def test_gen_multi_full_dist():
     probs = mit_counts.nearest_probability_distribution()
     assert np.allclose(mthree.utils.expval(probs), probs.expval())
     assert np.allclose(mthree.utils.stddev(probs), probs.stddev())
+
+def test_statevector_probs():
+    """Verify that probabilities from statevectors work"""
+    N = 4
+    qc = QuantumCircuit(N)
+    qc.x(range(4))
+    qc.h(range(4))
+    qc.ch(2, 1)
+    qc.ch(1, 0)
+    qc.ch(2, 3)
+
+    st = Statevector.from_instruction(qc)
+    probs = st.probabilities_dict()
+    assert np.allclose(mthree.utils.expval(probs), 0.5)

--- a/mthree/test/test_utils.py
+++ b/mthree/test/test_utils.py
@@ -114,6 +114,7 @@ def test_gen_multi_full_dist():
     assert np.allclose(mthree.utils.expval(probs), probs.expval())
     assert np.allclose(mthree.utils.stddev(probs), probs.stddev())
 
+
 def test_statevector_probs():
     """Verify that probabilities from statevectors work"""
     N = 4


### PR DESCRIPTION
There was a bad cast to int that was causing statevector probabilities to have an zero denominator in expvals