### PR TITLE
Fix wheel builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,2 @@
 [build-system]
 requires = ["setuptools", "wheel", "cython>=0.29", "oldest-supported-numpy"]
-build-backend = "setuptools.build_meta"


### PR DESCRIPTION
In #93 we added a pyproject.toml file to explicitly set build system
requirements (that included a stable version of numpy). But as part of
this change we also switched the build system to use the modern setuptools
path instead of the legacy one. This change had an inintended side
effect in that it didn't execute the setup.py file prior to processing
it. This led to the setup.py generated version.py file not being created
and the build would error. To address this this commit reverts back the
implicit default legacy build system. Moving forward if we want to use
the setuptools build system we'll likely need to move away from the
manual version.py generation and instead rely on a setuptools extension
package like PBR or setuptools_scm to handle the version management for
us. These are then compatible with the new setuptools build paths.