### PR TITLE
Do not skip Python 3.10 in builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           python-version: '3.7'
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.1.1
+        uses: pypa/cibuildwheel@v2.3.1
         env:
           CIBW_SKIP: "pp*"
           CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64 *-win32 *-manylinux_i686 cp39-manylinux*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.1.1
         env:
-          CIBW_SKIP: "cp310-* pp*"
+          CIBW_SKIP: "pp*"
           CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64 *-win32 *-manylinux_i686 cp39-manylinux*"
           CIBW_ARCHS_MACOS: x86_64 universal2
           CIBW_TEST_REQUIRES: pytest qiskit-aer

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,3 +10,4 @@ jupyter-sphinx
 nbsphinx
 psutil
 ipykernel<6
+Jinja2<3.1


### PR DESCRIPTION
This removes Py310 from the skip logic so that we build wheels for that version.