### PR TITLE
Patch calls to Qiskit direct

### DIFF
--- a/mthree/mitigation.py
+++ b/mthree/mitigation.py
@@ -23,7 +23,6 @@ import scipy.linalg as la
 import scipy.sparse.linalg as spla
 import orjson
 from qiskit import transpile, execute
-from qiskit.providers import Backend
 
 from mthree.circuits import (_tensor_meas_states, _marg_meas_states,
                              balanced_cal_strings, balanced_cal_circuits)

--- a/mthree/mitigation.py
+++ b/mthree/mitigation.py
@@ -307,7 +307,7 @@ class M3Mitigation():
             trans_qcs = transpile(circs, self.system, optimization_level=0)
 
         # This Backend check is here for Qiskit direct access.  Should be removed later.
-        if isinstance(self.system, Backend):
+        if self.system.__class__.__name__ == 'DirectBackend':
             job = execute(trans_qcs, self.system, optimization_level=0,
                           shots=self.cal_shots, rep_delay=self.rep_delay)
         else:


### PR DESCRIPTION
Qiskit Direct is typically not up to date with the latest and greatest of Qiskit, but support is still required.  In #100 `BaseBackend` was removed as it is deprecated.  It is still however used by Direct.  Here we just directly look for the class name `DirectBackend` to dispatch to `execute` that Direct still uses.