### PR TITLE
Simplfy check for Qiskit direct

### DIFF
--- a/mthree/mitigation.py
+++ b/mthree/mitigation.py
@@ -23,6 +23,7 @@ import scipy.linalg as la
 import scipy.sparse.linalg as spla
 import orjson
 from qiskit import transpile, execute
+from qiskit.providers import Backend
 
 from mthree.circuits import (_tensor_meas_states, _marg_meas_states,
                              balanced_cal_strings, balanced_cal_circuits)
@@ -306,7 +307,7 @@ class M3Mitigation():
             trans_qcs = transpile(circs, self.system, optimization_level=0)
 
         # This Backend check is here for Qiskit direct access.  Should be removed later.
-        if self.system.__class__.__name__ == 'DirectBackend':
+        if not isinstance(self.system, Backend):
             job = execute(trans_qcs, self.system, optimization_level=0,
                           shots=self.cal_shots, rep_delay=self.rep_delay)
         else:


### PR DESCRIPTION
At the suggestion of @mtreinish move to checking for not `Backend` to look for calls to Qiskit Direct.  Doesn't work when/if they update their code, but works for now and is cleaner.