### PR TITLE
DNM: Test wheel builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.3.1
         env:
           CIBW_SKIP: "cp36-* pp*"
-          CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64 *-win32 *-manylinux_i686"
+          CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64 *-win32 *-manylinux_i686 cp310-manylinux*"
           CIBW_ARCHS_MACOS: x86_64 universal2
           CIBW_TEST_REQUIRES: pytest qiskit-aer
           CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2014_x86_64:latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,9 +22,12 @@ jobs:
         uses: pypa/cibuildwheel@v2.3.1
         env:
           CIBW_SKIP: "cp36-* pp*"
-          CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64 *-win32 *-manylinux_i686 cp39-manylinux* cp310-manylinux*"
+          CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64 *-win32 *-manylinux_i686"
           CIBW_ARCHS_MACOS: x86_64 universal2
           CIBW_TEST_REQUIRES: pytest qiskit-aer
+          CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2014_x86_64:latest
+          CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux2014_i686:latest
+
           CIBW_TEST_COMMAND_LINUX: pytest -p no:warnings /mthree_test
           CIBW_TEST_COMMAND_WINDOWS: pytest -p no:warnings C:\Users\RUNNER~1\AppData\Local\Temp\mthree_test
           CIBW_TEST_COMMAND_MACOS:  pytest -p no:warnings /tmp/mthree_test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
         uses: pypa/cibuildwheel@v2.3.1
         env:
           CIBW_SKIP: "cp36-* pp*"
-          CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64 *-win32 *-manylinux_i686 cp39-manylinux*"
+          CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64 *-win32 *-manylinux_i686 cp39-manylinux* cp310-manylinux*"
           CIBW_ARCHS_MACOS: x86_64 universal2
           CIBW_TEST_REQUIRES: pytest qiskit-aer
           CIBW_TEST_COMMAND_LINUX: pytest -p no:warnings /mthree_test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.3.1
         env:
-          CIBW_SKIP: "cp36-* pp*"
+          CIBW_SKIP: "cp36-* pp* *musl*"
           CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64 *-win32 *-manylinux_i686 cp310-manylinux*"
           CIBW_ARCHS_MACOS: x86_64 universal2
           CIBW_TEST_REQUIRES: pytest qiskit-aer

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,9 @@
 name: Release Artifacts
 on:
   push:
-    tags:
-      - '*'
+    branches: [main]
+  pull_request:
+    branches: [main]
 jobs:
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
@@ -37,11 +38,6 @@ jobs:
       - name: Install twine
         run: |
           python -m pip install twine
-      - name: Publish to PyPi
-        env:
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_USERNAME: nonhermitian
-        run: twine upload ./wheelhouse/*whl
   sdist-build:
     name: Build and Publish Release Artifacts
     runs-on: ubuntu-latest
@@ -60,8 +56,3 @@ jobs:
       - uses: actions/upload-artifact@v2
         with:
           path: ./dist/mthree*
-      - name: Publish to PyPi
-        env:
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_USERNAME: nonhermitian
-        run: twine upload dist/mthree*


### PR DESCRIPTION
This commit is not intended to be merged. It's sole purpose is to
manually trigger the wheel building jobs in CI prior to the upcoming
release. We recently made some changes to the ci configuration for the
wheel jobs and before we tag the release it would be good to test it.