### PR TITLE
Fix cibuildhweel configuration

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,10 @@ jobs:
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.3.1
         env:
-          CIBW_SKIP: "cp36-* pp*"
-          CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64 *-win32 *-manylinux_i686 cp39-manylinux*"
+          CIBW_SKIP: "cp36-* pp* *musl*"
+          CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64 *-win32 *-manylinux_i686 cp310-manylinux*"
+          CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux2014_x86_64:latest
+          CIBW_MANYLINUX_I686_IMAGE: quay.io/pypa/manylinux2014_i686:latest
           CIBW_ARCHS_MACOS: x86_64 universal2
           CIBW_TEST_REQUIRES: pytest qiskit-aer
           CIBW_TEST_COMMAND_LINUX: pytest -p no:warnings /mthree_test


### PR DESCRIPTION
In prepartion for the upcoming release we recently pushed #107 to test
the ci configuration for wheel jobs was fully working. That test run
showed a few small issues in the configuration which would have caused
an error at release time. Primarily adding a build skip for musl linux
environments, a test skip for py310 because of an orjson issue, and
changing the base image to manylinux2014 instead of manylinux2010. The
only one which will have user facing impact is the manylinux version
change. By switching to manylinux2014 this means the wheels are only
compatible with linux systems with the same (or newer) glibc as what
shipped in centos/rhel 7. So for users on older versions of linux
they'll have to build the latest release from source.