### PR TITLE
Simpler batched operators

### DIFF
--- a/docs/grouped.rst
+++ b/docs/grouped.rst
@@ -64,7 +64,7 @@ If you have a single expectation value string then you do not need to wrap it in
 
 .. jupyter-execute::
 
-    quasi.expval([['IIII', 'ZZZZ', '0000', '1111'], 'IIII'])
+    quasis.expval([['IIII', 'ZZZZ', '0000', '1111'], 'IIII'])
 
 Of course probability-distributions work the same way as quasi-distributions:
 

--- a/docs/grouped.rst
+++ b/docs/grouped.rst
@@ -51,7 +51,7 @@ you want to evaluate them with:
 
 .. jupyter-execute::
 
-    expvals = quasis.expval([['IIII', 'ZZZZ', '0000', '1111'], ['IIII']])
+    quasis.expval([['IIII', 'ZZZZ', '0000', '1111'], ['IIII']])
 
 The return list has the expectation values grouped into NumPy arrays.  A similar procedure works
 for expectation values and standard deviations:
@@ -60,7 +60,13 @@ for expectation values and standard deviations:
 
     quasis.expval_and_stddev([['IIII', 'ZZZZ', '0000', '1111'], ['IIII']])
 
-Of course probabilities work the same way:
+If you have a single expectation value string then you do not need to wrap it in a list:
+
+.. jupyter-execute::
+
+    quasi.expval([['IIII', 'ZZZZ', '0000', '1111'], 'IIII'])
+
+Of course probability-distributions work the same way as quasi-distributions:
 
 .. jupyter-execute::
 

--- a/docs/grouped.rst
+++ b/docs/grouped.rst
@@ -1,0 +1,72 @@
+.. _grouped:
+
+#################
+Grouped operators
+#################
+
+Often times when evaluating expectation values it is possible to group operators
+together if the Pauli operators from which they are comprised commute with each other.  when
+possible, this batching can greatly reduce the number of executions needed.  To see how to do
+this consider the following simple example:
+
+.. jupyter-execute::
+
+    from qiskit import *
+    from qiskit.test.mock import FakeAthens
+    import mthree
+
+    qc = QuantumCircuit(4)
+    qc.h(0)
+    qc.cx(0, range(1, 4))
+    qc.measure_all()
+    qc.draw('mpl')
+
+Here we will generate and execute two circuits on the target system (fake system in this case),
+and, because we have transpiled, find the final measurement mapping:
+
+.. jupyter-execute::
+
+    backend = FakeAthens()
+    trans_circs = transpile([qc]*2, backend, optimization_level=3, approximation_degree=0)
+    mappings = mthree.utils.final_measurement_mapping(trans_circs)  
+
+Let us execute and get the resultant counts:
+
+.. jupyter-execute::
+
+    job = backend.run(trans_circs, shots=10000)
+    counts = job.result().get_counts()
+
+We can now mitigate as usual:
+
+.. jupyter-execute::
+
+    mit = mthree.M3Mitigation(backend)
+    mit.cals_from_system(mappings, shots=10000)
+    quasis = mit.apply_correction(counts, mappings, return_mitigation_overhead=True)
+
+Now that we have the final mitigated quasi-distributions we can compute expectation values.
+For batched operators, the expectation values are grouped together based on which quasi-distribution
+you want to evaluate them with:
+
+.. jupyter-execute::
+
+    expvals = quasis.expval([['IIII', 'ZZZZ', '0000', '1111'], ['IIII']])
+
+The return list has the expectation values grouped into NumPy arrays.  A similar procedure works
+for expectation values and standard deviations:
+
+.. jupyter-execute::
+
+    quasis.expval_and_stddev([['IIII', 'ZZZZ', '0000', '1111'], ['IIII']])
+
+Of course probabilities work the same way:
+
+.. jupyter-execute::
+
+    probs = quasis.nearest_probability_distribution()
+    probs.expval([['IIII', 'ZZZZ', '0000', '1111'], ['IIII']])
+
+.. jupyter-execute::
+
+    probs.expval_and_stddev([['IIII', 'ZZZZ', '0000', '1111'], ['IIII']])

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,6 +38,7 @@ residual (GMRES) or biconjugate gradient stabilized (BiCGSTAB) methods.
     Transpiled circuits <transpiled>
     Expectation values <expvals>
     Using collections <collections>
+    Grouped operators <grouped>
     Error analysis <error>
     Obtaining probabilities <probs>
     Saving and loading calibrations <cal_io>

--- a/mthree/classes.py
+++ b/mthree/classes.py
@@ -288,8 +288,8 @@ class QuasiCollection(list):
             out = []
             for idx, item in enumerate(self):
                 out.append(item.expval(exp_ops[idx]))
-            return np.array(out, dtype=float)
-        return np.array([item.expval(exp_ops) for item in self], dtype=float)
+            return out
+        return [item.expval(exp_ops) for item in self]
 
     def expval_and_stddev(self, exp_ops=''):
         """Expectation value and standard deviation over entire collection.
@@ -390,7 +390,7 @@ class ProbCollection(list):
             out = []
             for idx, item in enumerate(self):
                 out.append(item.expval(exp_ops[idx]))
-            return np.array(out, dtype=float)
+            return out
         return np.array([item.expval(exp_ops) for item in self], dtype=float)
 
     def expval_and_stddev(self, exp_ops=''):

--- a/mthree/classes.py
+++ b/mthree/classes.py
@@ -288,8 +288,10 @@ class QuasiCollection(list):
             out = []
             for idx, item in enumerate(self):
                 out.append(item.expval(exp_ops[idx]))
+            if not isinstance(out[0], (list, np.ndarray)):
+                return np.asarray(out, dtype=float)
             return out
-        return [item.expval(exp_ops) for item in self]
+        return np.array([item.expval(exp_ops) for item in self])
 
     def expval_and_stddev(self, exp_ops=''):
         """Expectation value and standard deviation over entire collection.
@@ -390,6 +392,8 @@ class ProbCollection(list):
             out = []
             for idx, item in enumerate(self):
                 out.append(item.expval(exp_ops[idx]))
+            if not isinstance(out[0], (list, np.ndarray)):
+                return np.asarray(out, dtype=float)
             return out
         return np.array([item.expval(exp_ops) for item in self], dtype=float)
 

--- a/mthree/classes.py
+++ b/mthree/classes.py
@@ -288,7 +288,7 @@ class QuasiCollection(list):
             out = []
             for idx, item in enumerate(self):
                 out.append(item.expval(exp_ops[idx]))
-            if not isinstance(out[0], (list, np.ndarray)):
+            if not any(isinstance(item, (list, np.ndarray)) for item in out):
                 return np.asarray(out, dtype=float)
             return out
         return np.array([item.expval(exp_ops) for item in self])
@@ -392,7 +392,7 @@ class ProbCollection(list):
             out = []
             for idx, item in enumerate(self):
                 out.append(item.expval(exp_ops[idx]))
-            if not isinstance(out[0], (list, np.ndarray)):
+            if not any(isinstance(item, (list, np.ndarray)) for item in out):
                 return np.asarray(out, dtype=float)
             return out
         return np.array([item.expval(exp_ops) for item in self], dtype=float)

--- a/mthree/test/test_grouping.py
+++ b/mthree/test/test_grouping.py
@@ -1,0 +1,51 @@
+# This code is part of Mthree.
+#
+# (C) Copyright IBM 2022.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+# pylint: disable=no-name-in-module
+
+"""Test opertor groupings"""
+from cmath import exp
+import numpy as np
+from qiskit import QuantumCircuit, transpile
+from qiskit.test.mock import FakeAthens
+import mthree
+
+
+def test_groupings1():
+    """Test grouping of operators ouput
+    """
+    backend = FakeAthens()
+    qc = QuantumCircuit(4)
+    qc.h(0)
+    qc.cx(0, range(1, 4))
+    qc.measure_all()
+
+    trans_circs = transpile([qc]*2, backend, optimization_level=3,
+                            approximation_degree=0)
+    mappings = mthree.utils.final_measurement_mapping(trans_circs)
+
+    job = backend.run(trans_circs, shots=10000)
+    counts = job.result().get_counts()
+
+    mit = mthree.M3Mitigation(backend)
+    mit.cals_from_system(mappings, shots=10000)
+
+    quasis = mit.apply_correction(counts, mappings, return_mitigation_overhead=True)
+    expvals = quasis.expval([['IIII', 'ZZZZ', '0000', '1111'], ['IIII', '1111']])
+
+    assert expvals[0].shape[0] == 4
+    assert np.allclose(expvals[0][0], 1)
+    assert np.allclose(expvals[1][0], 1)
+    assert np.allclose(expvals[0][2], quasis[0]['0000'])
+    assert np.allclose(expvals[0][3], quasis[0]['1111'])
+    assert expvals[1].shape[0] == 2
+    assert np.allclose(expvals[1][0], 1)
+    assert np.allclose(expvals[1][1], quasis[1]['1111'])

--- a/mthree/test/test_grouping.py
+++ b/mthree/test/test_grouping.py
@@ -12,7 +12,6 @@
 # pylint: disable=no-name-in-module
 
 """Test opertor groupings"""
-from cmath import exp
 import numpy as np
 from qiskit import QuantumCircuit, transpile
 from qiskit.test.mock import FakeAthens

--- a/mthree/test/test_grouping.py
+++ b/mthree/test/test_grouping.py
@@ -73,3 +73,8 @@ def test_groupings2():
 
     assert np.allclose(expvals[0], 1.0)
     assert expvals[1].shape[0] == 2
+
+    probs = quasis.nearest_probability_distribution()
+    expvals2 = probs.expval(['IIII', ['IIII', '1111']])
+    assert np.allclose(expvals2[0], 1.0)
+    assert expvals2[1].shape[0] == 2


### PR DESCRIPTION
fixes #112 

Allows for doing batched operations on operators, such as:

```python

quasis.expval(['IIII', ['IIII', '0000'], 'IIII'])
```

```python
[1.0000000000000004, array([1.        , 0.49273162]), 1.0]
```

and 

```python
quasis.expval_and_stddev(['IIII', ['IIII', '0000'], 'IIII'])
```

```python
[(1.0000000000000004, 0.012176611465756097),
 (array([1.        , 0.49273162]), 0.012176611465756099),
 (1.0, 0.012612841363264259)]
```