### PR TITLE
[WIP] Add marginal distribution routines

### DIFF
--- a/mthree/marginals.pyx
+++ b/mthree/marginals.pyx
@@ -1,0 +1,78 @@
+# This code is part of Mthree.
+#
+# (C) Copyright IBM 2022.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+# cython: c_string_type=unicode, c_string_encoding=UTF-8
+cimport cython
+from libcpp.string cimport string
+from libcpp.unordered_map cimport unordered_map  as map
+
+@cython.boundscheck(False)
+def cy_marginal_counts(object counts, int[::1] indices):
+    """Computes marginal counts from a given dictionary for the supplied indices.
+    
+    Parameters:
+        counts (dict): Input counts dictionary with integer values.
+        indices (ndarray): Int32 array of indices to keep.
+        
+    Returns:
+        dict: Dictionary of marginal counts
+    """
+    cdef map[string, int] new_counts
+    cdef map[string, int].iterator it
+    cdef string key, new_key
+    cdef int val
+    cdef unsigned int key_len = len(next(iter(counts)))
+    cdef size_t idx
+    cdef unsigned int ind_len = indices.shape[0]
+
+    new_key = '0'*ind_len
+    for key, val in counts.items():
+        for idx in range(ind_len):
+            new_key[ind_len-idx-1] = key[key_len-indices[idx]-1]
+        
+        it = new_counts.find(new_key)
+        if it == new_counts.end():
+            new_counts[new_key] = val
+        else:
+            new_counts[new_key] += val
+    return new_counts
+
+
+@cython.boundscheck(False)
+def cy_marginal_distribution(object counts, int[::1] indices):
+    """Computes marginal distribution from a given dictionary for the supplied indices.
+    
+    Parameters:
+        counts (dict): Input counts dictionary with double values.
+        indices (ndarray): Int32 array of indices to keep.
+        
+    Returns:
+        dict: Dictionary of marginal counts
+    """
+    cdef map[string, double] new_counts
+    cdef map[string, double].iterator it
+    cdef string key, new_key
+    cdef double val
+    cdef unsigned int key_len = len(next(iter(counts)))
+    cdef size_t idx
+    cdef unsigned int ind_len = indices.shape[0]
+
+    new_key = '0'*ind_len
+    for key, val in counts.items():
+        for idx in range(ind_len):
+            new_key[ind_len-idx-1] = key[key_len-indices[idx]-1]
+        
+        it = new_counts.find(new_key)
+        if it == new_counts.end():
+            new_counts[new_key] = val
+        else:
+            new_counts[new_key] += val
+    return new_counts

--- a/mthree/utils.py
+++ b/mthree/utils.py
@@ -23,10 +23,12 @@ Utility functions
    expval_and_stddev
 
 """
+import numbers
 import numpy as np
 from mthree.exceptions import M3Error
 from mthree.classes import (QuasiDistribution, ProbDistribution,
                             QuasiCollection, ProbCollection)
+from mthree.marginals import cy_marginal_counts, cy_marginal_distribution
 
 
 def final_measurement_mapping(circuit):
@@ -52,6 +54,60 @@ def final_measurement_mapping(circuit):
     if not given_list:
         return maps_out[0]
     return maps_out
+
+
+def marginal_distribution(dist, indices, mapping=None):
+    """Grab the marginal counts from a given distribution.
+    
+    If an operator is passed for the `indices` then the position of the
+    non-identity elements in the string will be used to set the indices
+    to marginalize over.
+    
+    The mapping
+    
+    Parameters:
+        dist (dict): Input distribution
+        indices (array_like or str): Indices (qubits) to keep or operator string
+        mapping (dict or array_like): Optional, final measurement mapping.
+        
+    Returns:
+        dict: Marginal distribution
+        list or dict: The reduced mapping if an optional mapping (list or dict) is given
+        
+    Raises:
+        M3Error: Operator length does not equal bit-string length
+        M3Error: One or more indices is out of bounds
+    """
+    key_len = len(next(iter(dist)))
+    val = next(iter(dist.values()))
+    
+    if isinstance(indices, str):
+        indices = indices.upper()
+        if len(indices) != key_len:
+            raise M3Error('Operator length does not equal distribution bit-string length.')
+        indices = [(key_len-kk-1) for kk in range(key_len-1, -1, -1) if indices[kk] != 'I']
+    indices = np.asarray(indices, dtype=np.int32)
+    if np.any(indices >= key_len):
+        raise M3Error('One or more out of bound indices for distribution bit-string length ({}).'.format(key_len))
+    is_counts = False
+    if isinstance(val, numbers.Integral):
+        is_counts = True
+    if is_counts:
+        out_dist = cy_marginal_counts(dist, indices)
+    else:
+        out_dist = cy_marginal_distribution(dist, indices)
+        
+    if mapping:
+        if isinstance(mapping, list):
+            out_mapping = [mapping[kk] for kk in indices]
+        else:
+            # mapping is a dict
+            out_mapping = {}
+            inv_mapping = dict((v, k) for k, v in mapping.items())
+            for idx, ind in enumerate(indices):
+                out_mapping[inv_mapping[ind]] = idx
+        return out_dist, out_mapping
+    return out_dist
 
 
 def _final_measurement_mapping(circuit):

--- a/setup.py
+++ b/setup.py
@@ -43,10 +43,10 @@ with open(os.path.join(this_dir, 'README.md'), encoding='utf-8') as readme:
     LONG_DESCRIPTION = readme.read()
 
 CYTHON_EXTS = ['compute', 'converters', 'hamming', 'matrix', 'probability', 'matvec'] + \
-              ['expval', 'column_testing', 'converters_testing']
-CYTHON_MODULES = ['mthree']*7 + \
+              ['expval', 'marginals', 'column_testing', 'converters_testing']
+CYTHON_MODULES = ['mthree']*8 + \
                  ['mthree.test']*2
-CYTHON_SOURCE_DIRS = ['mthree']*7 + \
+CYTHON_SOURCE_DIRS = ['mthree']*8 + \
                      ['mthree/test']*2
 
 # Add openmp flags


### PR DESCRIPTION
For low-weight operator it is more efficient to marginalized the input distribution (counts) over those qubits with non-identity operators only.  This gives a much smaller state space over which to mitigate and makes things much faster.  

This PR adds routines for marginalizing distributions given indices or operators as strings.  Optionally a qubit to bit mapping can be passed, which will also be marginalized so that it can be directly used in `apply_correction`