### PR TITLE
Only build release wheels with openmp on linux

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
           CIBW_TEST_COMMAND_LINUX: pytest -p no:warnings /mthree_test
           CIBW_TEST_COMMAND_WINDOWS: pytest -p no:warnings C:\Users\RUNNER~1\AppData\Local\Temp\mthree_test
           CIBW_TEST_COMMAND_MACOS:  pytest -p no:warnings /tmp/mthree_test
-          CIBW_ENVIRONMENT: MTHREE_OPENMP=1
+          CIBW_ENVIRONMENT_LINUX: MTHREE_OPENMP=1
           CIBW_BEFORE_TEST_LINUX: rm -rf /mthree_test && cp -r {project}/mthree/test /mthree_test && rm -f /mthree_test/test_converters.py && rm -f /mthree_test/test_columns.py
           CIBW_BEFORE_TEST_WINDOWS: rm -rf C:\Users\RUNNER~1\AppData\Local\Temp\mthree_test && cp -r {project}/mthree/test C:\Users\RUNNER~1\AppData\Local\Temp\mthree_test && rm -f C:\Users\RUNNER~1\AppData\Local\Temp\mthree_test\test_converters.py && rm -f C:\Users\RUNNER~1\AppData\Local\Temp\mthree_test\test_columns.py && pip install --prefer-binary orjson
           CIBW_BEFORE_TEST_MACOS: rm -rf /tmp/mthree_test && cp -r {project}/mthree/test /tmp/mthree_test && rm -f /tmp/mthree_test/test_converters.py && rm -f /tmp/mthree_test/test_columns.py


### PR DESCRIPTION
As was discovered during the recent 0.24 release building with openmp
support on macOS and Windows fails to compile in the default
ci environment and the job will fail. This commit disables building with
openmp on those platforms so we only set the flag for linux builds. This
should fix future releases' builds so they build and publish without
issue.