### PR TITLE
Do not count delay operations in final_measurement_mapping

### DIFF
--- a/mthree/test/test_meas_mapping.py
+++ b/mthree/test/test_meas_mapping.py
@@ -89,3 +89,15 @@ def test_mapping_list():
 
     maps = final_measurement_mapping(qc)
     assert not isinstance(maps, list)
+
+
+def test_mapping_w_delays():
+    """Check that measurements followed by delays get in the mapping"""
+    qc = QuantumCircuit(2, 2)
+    qc.measure(0, 1)
+    qc.delay(10, 0)
+    qc.measure(1, 0)
+    qc.barrier()
+
+    maps = final_measurement_mapping(qc)
+    assert maps == {1: 0, 0: 1}

--- a/mthree/utils.py
+++ b/mthree/utils.py
@@ -139,7 +139,7 @@ def _final_measurement_mapping(circuit):
                 cmap.append(cbit)
                 active_cbits.remove(cbit)
                 active_qubits.remove(qbit)
-        elif item[0].name != "barrier":
+        elif item[0].name not in ["barrier", "delay"]:
             for qq in item[1]:
                 _temp_qubit = qint_map[qq]
                 if _temp_qubit in active_qubits:


### PR DESCRIPTION
If a circuit is scheduled it is possible to have `delay` operations at the end (https://github.com/Qiskit/qiskit-ibm-runtime/issues/481).  These should not affect the `final_measurement_mapping`.  This fixes that.