### PR TITLE
Bump main to version 2.0

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ qiskit>=0.28
 pytest
 pylint
 pycodestyle
-Sphinx<4
+Sphinx<6
 qiskit_sphinx_theme
 matplotlib
 pylatexenc

--- a/setup.py
+++ b/setup.py
@@ -22,9 +22,8 @@ import setuptools
 import numpy as np
 from Cython.Build import cythonize
 
-
-MAJOR = 1
-MINOR = 2
+MAJOR = 2
+MINOR = 0
 MICRO = 0
 
 ISRELEASED = False


### PR DESCRIPTION
An upcoming change to the qubit - cbit mappings routine breaks backward compatibility.  We could introduce a new class that preserves the old functionality, and supports the new.  However, I am not in favor of having classes for the sake of classes, and version numbers are free.  Since nothing in 1.x is broken (that we know of), those who prefer to stay that this lower version can do so.