### PR TITLE
Bump action to Py39

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/setup-python@v2
         name: Install Python
         with:
-          python-version: '3.7'
+          python-version: '3.9'
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.3.1
         env:


### PR DESCRIPTION
The release workflow was using Py37, which is now approaching EOL.  This bumps the version to Py39