### PR TITLE
Bump cibuildwheel version to latest and add Py3.11 support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,9 @@
 name: Release Artifacts
 on:
   push:
-    tags:
-      - '*'
+    branches: [main]
+  pull_request:
+    branches: [main]
 jobs:
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
@@ -39,31 +40,3 @@ jobs:
       - name: Install twine
         run: |
           python -m pip install twine
-      - name: Publish to PyPi
-        env:
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_USERNAME: nonhermitian
-        run: twine upload ./wheelhouse/*whl
-  sdist-build:
-    name: Build and Publish Release Artifacts
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-python@v2
-        name: Install Python
-        with:
-          python-version: '3.9'
-      - name: Install Deps
-        run: pip install -U twine cython numpy
-      - name: Build Artifacts
-        run: |
-          python setup.py sdist
-        shell: bash
-      - uses: actions/upload-artifact@v2
-        with:
-          path: ./dist/mthree*
-      - name: Publish to PyPi
-        env:
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
-          TWINE_USERNAME: nonhermitian
-        run: twine upload dist/mthree*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
         with:
           python-version: '3.9'
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.3.1
+        uses: pypa/cibuildwheel@v2.12.0
         env:
           CIBW_SKIP: "cp36-* pp* *musl*"
           CIBW_TEST_SKIP: "*-macosx_arm64 *-macosx_universal2:arm64 *-win32 *-manylinux_i686 cp310-manylinux*"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,8 @@
 name: Release Artifacts
 on:
   push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+    tags:
+      - '*'
 jobs:
   build_wheels:
     name: Build wheels on ${{ matrix.os }}
@@ -40,3 +39,31 @@ jobs:
       - name: Install twine
         run: |
           python -m pip install twine
+      - name: Publish to PyPi
+        env:
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          TWINE_USERNAME: nonhermitian
+        run: twine upload ./wheelhouse/*whl
+  sdist-build:
+    name: Build and Publish Release Artifacts
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        name: Install Python
+        with:
+          python-version: '3.9'
+      - name: Install Deps
+        run: pip install -U twine cython numpy
+      - name: Build Artifacts
+        run: |
+          python setup.py sdist
+        shell: bash
+      - uses: actions/upload-artifact@v2
+        with:
+          path: ./dist/mthree*
+      - name: Publish to PyPi
+        env:
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          TWINE_USERNAME: nonhermitian
+        run: twine upload dist/mthree*

--- a/setup.py
+++ b/setup.py
@@ -204,6 +204,7 @@ setuptools.setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "Topic :: Scientific/Engineering",
     ],
     cmdclass={'lint': PylintCommand,


### PR DESCRIPTION
This commit bumps the cibuildwheel version to the latest release. This enables building python 3.11 wheels in addition to just bumping the python build toolchain we're using to build the wheels. Prior to merging this commit we should do a manual test commit to run this on the PR and not publish the build artifacts to ensure the job still works as configured, and if there are any issues fix them on the branch prior to reverting the test commit.