### PR TITLE
Set cal method by backend type

### DIFF
--- a/docs/balanced.rst
+++ b/docs/balanced.rst
@@ -34,8 +34,11 @@ matches the precison of the other methods.  That is to say that the following:
  .. jupyter-execute::
 
     backend = FakeAthens()
-    mit = mthree.M3Mitigation(backend)
+    mit = mthree.M3Mitigation(backend, method='balanced')
     mit.cals_from_system(shots=10000)
 
-Will sample each qubit error rate `10000` times regardless of which method is used.  Moreover, this
-also yields a calibration process whose overhead is independent of the number of qubits used.
+Will sample each qubit error rate `10000` times regardless of which method is used.  Moreover,
+this also yields a calibration process whose overhead is independent of the number of qubits
+used.  Note that, when using a simulator or "fake" device, M3 defaults to `independent`
+calibration mode for efficiency.  As such, to enable `balanced` calibration on a simulator
+one must explicitly set the `method`` as done above.

--- a/docs/balanced.rst
+++ b/docs/balanced.rst
@@ -34,8 +34,8 @@ matches the precison of the other methods.  That is to say that the following:
  .. jupyter-execute::
 
     backend = FakeAthens()
-    mit = mthree.M3Mitigation(backend, method='balanced')
-    mit.cals_from_system(shots=10000)
+    mit = mthree.M3Mitigation(backend)
+    mit.cals_from_system(method='balanced')
 
 Will sample each qubit error rate `10000` times regardless of which method is used.  Moreover,
 this also yields a calibration process whose overhead is independent of the number of qubits

--- a/mthree/mitigation.py
+++ b/mthree/mitigation.py
@@ -132,7 +132,7 @@ class M3Mitigation():
                               rep_delay=rep_delay,
                               cals_file=cals_file)
 
-    def cals_from_system(self, qubits=None, shots=None, method='balanced',
+    def cals_from_system(self, qubits=None, shots=None, method=None,
                          initial_reset=False, rep_delay=None, cals_file=None,
                          async_cal=False):
         """Grab calibration data from system.
@@ -140,7 +140,8 @@ class M3Mitigation():
         Parameters:
             qubits (array_like): Qubits over which to correct calibration data. Default is all.
             shots (int): Number of shots per circuit. min(1e4, max_shots).
-            method (str): Type of calibration, 'balanced' (default), 'independent', or 'marginal'.
+            method (str): Type of calibration, 'balanced' (default for hardware),
+                         'independent' (default for simulators), or 'marginal'.
             initial_reset (bool): Use resets at beginning of calibration circuits, default=False.
             rep_delay (float): Delay between circuits on IBM Quantum backends.
             cals_file (str): Output path to write JSON calibration data to.
@@ -153,6 +154,10 @@ class M3Mitigation():
             raise M3Error('Calibration currently in progress.')
         if qubits is None:
             qubits = range(self.num_qubits)
+        if method is None:
+            method = 'balanced'
+            if self.system.configuration().simulator:
+                method = 'independent'
         self.cal_method = method
         self.rep_delay = rep_delay
         self.cal_timestamp = None


### PR DESCRIPTION
One of the pain-points for users is that noisy simulators do not handle the `balanced` calibrations well since they range over the full topology width.  The `independent` method is preferred for simulators because, at least in the case of Aer, the circuits are truncated to only those qubits actually used.  For `independent` cals, this means circuits containing a single-qubit only.  As this makes simulations much faster, this PR adds logic to auto-select this method when a simulator backend is passed.