### PR TITLE
Fix saving cals incompatible with async cal mode

### DIFF
--- a/mthree/mitigation.py
+++ b/mthree/mitigation.py
@@ -60,6 +60,8 @@ class M3Mitigation():
         # attributes for handling threaded job
         self._thread = None
         self._job_error = None
+        # Holds the cals file
+        self.cals_file = None
 
     def __getattribute__(self, attr):
         """This allows for checking the status of the threaded cals call
@@ -160,12 +162,11 @@ class M3Mitigation():
                 method = 'independent'
         self.cal_method = method
         self.rep_delay = rep_delay
+        self.cals_file = cals_file
         self.cal_timestamp = None
         self._grab_additional_cals(qubits, shots=shots,  method=method,
                                    rep_delay=rep_delay, initial_reset=initial_reset,
                                    async_cal=async_cal)
-        if cals_file:
-            self.cals_to_file(cals_file)
 
     def cals_from_file(self, cals_file):
         """Generated the calibration data from a previous runs output
@@ -747,5 +748,9 @@ def _job_thread(job, mit, method, qubits, num_cal_qubits, cal_strings):
         for idx, cal in enumerate(cals):
             mit.single_qubit_cals[qubits[idx]] = cal
 
+    # save cals to file, if requested
+    if mit.cals_file:
+        mit.cals_to_file(mit.cals_file)
+    # Return list of faulty qubits, if any
     if any(bad_list):
         mit._job_error = M3Error('Faulty qubits detected: {}'.format(bad_list))

--- a/mthree/test/test_threading.py
+++ b/mthree/test/test_threading.py
@@ -45,5 +45,5 @@ def test_test_call_cals_twice():
 
     # Test that I can save cals while in async mode
     with pytest.raises(M3Error):
-        cal_file = 'data' / "cal.json"
+        cal_file = "data_cal.json"
         mit.cals_from_system(maps, cals_file=cal_file, async_cal=True)

--- a/mthree/test/test_threading.py
+++ b/mthree/test/test_threading.py
@@ -42,3 +42,8 @@ def test_test_call_cals_twice():
     with pytest.raises(M3Error):
         mit.cals_from_system(maps, async_cal=True)
         mit.cals_from_system(maps)
+
+    # Test that I can save cals while in async mode
+    with pytest.raises(M3Error):
+        cal_file = 'data' / "cal.json"
+        mit.cals_from_system(maps, cals_file=cal_file, async_cal=True)


### PR DESCRIPTION
This moves the save cals routine into the threaded part of the code, and executes at the end, right before raising if any faulty qubits, so that the results can be viewed.

fixes #129 