### PR TITLE
Calibrate unique qubit indices only

### DIFF
--- a/mthree/mitigation.py
+++ b/mthree/mitigation.py
@@ -288,14 +288,14 @@ class M3Mitigation():
 
         if isinstance(qubits, dict):
             # Assuming passed a mapping
-            qubits = list(qubits.values())
+            qubits = list(set(qubits.values()))
         elif isinstance(qubits, list):
             # Check if passed a list of mappings
             if isinstance(qubits[0], dict):
                 # Assuming list of mappings, need to get unique elements
                 _qubits = []
                 for item in qubits:
-                    _qubits.extend(list(item.values()))
+                    _qubits.extend(list(set(item.values())))
                 qubits = list(set(_qubits))
 
         num_cal_qubits = len(qubits)


### PR DESCRIPTION
When allowing for mid-circuit measurement mitigation the values of the mapping dict are physical qubit indices.  These indices are in general not unique, and I did not account for that in the calibrations.  This fixes that by first making a `set` before making a list