### PR TITLE
[WIP] Relax faulty qubit checking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -133,3 +133,4 @@ mthree/version.py
 docs/*.json
 docs/stubs/*
 docs/tutorials/
+bad_cals.json

--- a/mthree/mitigation.py
+++ b/mthree/mitigation.py
@@ -756,7 +756,7 @@ def _job_thread(job, mit, method, qubits, num_cal_qubits, cal_strings):
                 else:
                     cal[1, 1] += good_prep[kk] / denom
 
-        for jj, cal in enumerate(cals):
+        for cal in cals:
             cal[1, 0] = 1.0 - cal[0, 0]
             cal[0, 1] = 1.0 - cal[1, 1]
 

--- a/mthree/mitigation.py
+++ b/mthree/mitigation.py
@@ -769,6 +769,7 @@ def _job_thread(job, mit, method, qubits, num_cal_qubits, cal_strings):
     # faulty qubits, if any
     mit.faulty_qubits = _faulty_qubit_checker(mit.single_qubit_cals)
 
+
 def _faulty_qubit_checker(cals):
     """Find faulty qubits in cals
 

--- a/mthree/mitigation.py
+++ b/mthree/mitigation.py
@@ -760,24 +760,21 @@ def _job_thread(job, mit, method, qubits, num_cal_qubits, cal_strings):
             cal[1, 0] = 1.0 - cal[0, 0]
             cal[0, 1] = 1.0 - cal[1, 1]
 
-            if cal[0, 1] >= cal[0, 0]:
-                bad_list.append(qubits[jj])
-
         for idx, cal in enumerate(cals):
             mit.single_qubit_cals[qubits[idx]] = cal
 
     # save cals to file, if requested
     if mit.cals_file:
         mit.cals_to_file(mit.cals_file)
-    # Append list of faulty qubits, if any
-    mit.faulty_qubits = bad_list
+    # faulty qubits, if any
+    mit.faulty_qubits = _faulty_qubit_checker(mit.single_qubit_cals)
 
 def _faulty_qubit_checker(cals):
     """Find faulty qubits in cals
-    
+
     Parameters:
         cals (list): Input list of calibrations
-    
+
     Returns:
         list: Faulty qubits
     """

--- a/mthree/test/test_faulty.py
+++ b/mthree/test/test_faulty.py
@@ -22,15 +22,14 @@ def test_faulty_logic():
     """Test faulty qubits block correction"""
 
     mit = mthree.M3Mitigation(None)
-    mit.single_qubit_cals = [np.array([[0.9819, 0.043 ],
-                                       [0.0181, 0.957 ]]),
+    mit.single_qubit_cals = [np.array([[0.9819, 0.043],
+                                       [0.0181, 0.957]]),
                              np.array([[0.4849, 0.5233],
                                        [0.5151, 0.4767]]),
                              np.array([[0.9092, 0.4021],
                                        [0.0908, 0.5979]]),
                              np.array([[0.4117, 0.8101],
-                                       [0.5883, 0.1899]])
-                            ]
+                                       [0.5883, 0.1899]])]
     mit.faulty_qubits = [1, 3]
     counts = {"00": 0.4, "01": 0.1, "11": 0.5}
     with pytest.raises(mthree.exceptions.M3Error) as _:
@@ -40,17 +39,15 @@ def test_faulty_logic():
 def test_faulty_io():
     """Check round-tripping IO still has faulty qubits"""
     mit = mthree.M3Mitigation(None)
-    mit.single_qubit_cals = [np.array([[0.9819, 0.043 ],
-                                       [0.0181, 0.957 ]]),
+    mit.single_qubit_cals = [np.array([[0.9819, 0.043],
+                                       [0.0181, 0.957]]),
                              np.array([[0.4849, 0.5233],
                                        [0.5151, 0.4767]]),
                              np.array([[0.9092, 0.4021],
                                        [0.0908, 0.5979]]),
                              np.array([[0.4117, 0.8101],
-                                       [0.5883, 0.1899]])
-                            ]
+                                       [0.5883, 0.1899]])]
     mit.cals_to_file('bad_cals.json')
-
     mit2 = mthree.M3Mitigation(None)
     mit2.cals_from_file('bad_cals.json')
     assert mit2.faulty_qubits == [1, 3]

--- a/mthree/test/test_faulty.py
+++ b/mthree/test/test_faulty.py
@@ -1,0 +1,56 @@
+# This code is part of Mthree.
+#
+# (C) Copyright IBM 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+# pylint: disable=no-name-in-module
+
+"""Test faulty qubits handling"""
+import numpy as np
+import pytest
+
+import mthree
+
+
+def test_faulty_logic():
+    """Test faulty qubits block correction"""
+
+    mit = mthree.M3Mitigation(None)
+    mit.single_qubit_cals = [np.array([[0.9819, 0.043 ],
+                                       [0.0181, 0.957 ]]),
+                             np.array([[0.4849, 0.5233],
+                                       [0.5151, 0.4767]]),
+                             np.array([[0.9092, 0.4021],
+                                       [0.0908, 0.5979]]),
+                             np.array([[0.4117, 0.8101],
+                                       [0.5883, 0.1899]])
+                            ]
+    mit.faulty_qubits = [1, 3]
+    counts = {"00": 0.4, "01": 0.1, "11": 0.5}
+    with pytest.raises(mthree.exceptions.M3Error) as _:
+        _ = mit.apply_correction(counts, qubits= [3, 2])
+
+
+def test_faulty_io():
+    """Check round-tripping IO still has faulty qubits"""
+    mit = mthree.M3Mitigation(None)
+    mit.single_qubit_cals = [np.array([[0.9819, 0.043 ],
+                                       [0.0181, 0.957 ]]),
+                             np.array([[0.4849, 0.5233],
+                                       [0.5151, 0.4767]]),
+                             np.array([[0.9092, 0.4021],
+                                       [0.0908, 0.5979]]),
+                             np.array([[0.4117, 0.8101],
+                                       [0.5883, 0.1899]])
+                            ]
+    mit.cals_to_file('bad_cals.json')
+
+    mit2 = mthree.M3Mitigation(None)
+    mit2.cals_from_file('bad_cals.json')
+    assert mit2.faulty_qubits == [1, 3]

--- a/mthree/test/test_faulty.py
+++ b/mthree/test/test_faulty.py
@@ -33,7 +33,7 @@ def test_faulty_logic():
     mit.faulty_qubits = [1, 3]
     counts = {"00": 0.4, "01": 0.1, "11": 0.5}
     with pytest.raises(mthree.exceptions.M3Error) as _:
-        _ = mit.apply_correction(counts, qubits= [3, 2])
+        _ = mit.apply_correction(counts, qubits=[3, 2])
 
 
 def test_faulty_io():

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ import numpy as np
 from Cython.Build import cythonize
 
 MAJOR = 2
-MINOR = 2
+MINOR = 3
 MICRO = 0
 
 ISRELEASED = False


### PR DESCRIPTION
When using M3, it takes the same overhead to calibrate an entire device as it does a single qubit.  As such, it is best to just calibrate everything and leave it at that.  However, when doing so on a large device, M3 could raise on the faulty qubit warning even if the bad qubits in question were not going to be used in the actual mitigation process.

This PR relaxes the faulty qubit checking, and will only raise if the faulty qubits are going to be used for mitigation