### PR TITLE
Update for faulty qubits

### DIFF
--- a/mthree/_helpers.py
+++ b/mthree/_helpers.py
@@ -50,10 +50,10 @@ def system_info(backend):
         # outside of configuration?
         if hasattr(backend, 'configuration'):
             info_dict["simulator"] = backend.configuration().simulator
+    else:
+        raise M3Error('Invalid backend passed.')
     # Look for faulty qubits.  Renaming to 'inoperable' here
     if hasattr(backend, 'properties'):
         if hasattr(backend.properties(), 'faulty_qubits'):
             info_dict["inoperable_qubits"] = backend.properties().faulty_qubits()
-    else:
-        raise M3Error('Invalid backend passed.')
     return info_dict

--- a/mthree/_helpers.py
+++ b/mthree/_helpers.py
@@ -27,6 +27,7 @@ def system_info(backend):
         dict: Backend information
     """
     info_dict = {}
+    info_dict["inoperable_qubits"] = []
     if isinstance(backend, BackendV1):
         config = backend.configuration()
         info_dict["name"] = backend.name()
@@ -49,6 +50,10 @@ def system_info(backend):
         # outside of configuration?
         if hasattr(backend, 'configuration'):
             info_dict["simulator"] = backend.configuration().simulator
+    # Look for faulty qubits.  Renaming to 'inoperable' here
+    if hasattr(backend, 'properties'):
+        if hasattr(backend.properties(), 'faulty_qubits'):
+            info_dict["inoperable_qubits"] = backend.properties().faulty_qubits()
     else:
         raise M3Error('Invalid backend passed.')
     return info_dict

--- a/mthree/mitigation.py
+++ b/mthree/mitigation.py
@@ -166,16 +166,11 @@ class M3Mitigation():
             # Remove faulty qubits if any
             if any(self.system_info['inoperable_qubits']):
                 qubits = list(filter(lambda item: item not in
-                    self.system_info['inoperable_qubits'], list(range(self.num_qubits))))
+                                      self.system_info['inoperable_qubits'],
+                                      list(range(self.num_qubits))))
                 warnings.warn('Backend reporting inoperable qubits.' +
                               ' Skipping calibrations for: {}' \
                                 .format(self.system_info['inoperable_qubits']))
-
-        else:
-            inoperable_overlap = list(set(qubits) & set(self.system_info['inoperable_qubits']))
-            if any(inoperable_overlap):
-                raise M3Error('Attempting to calibrate inoperable qubits: {}' \
-                    .format(inoperable_overlap))
         if method is None:
             method = 'balanced'
             if self.system_info["simulator"]:
@@ -314,6 +309,12 @@ class M3Mitigation():
                 for item in qubits:
                     _qubits.extend(list(set(item.values())))
                 qubits = list(set(_qubits))
+    
+        # Do check for inoperable qubits here
+        inoperable_overlap = list(set(qubits) & set(self.system_info['inoperable_qubits']))
+        if any(inoperable_overlap):
+            raise M3Error('Attempting to calibrate inoperable qubits: {}' \
+                .format(inoperable_overlap))
 
         num_cal_qubits = len(qubits)
         cal_strings = []
@@ -649,7 +650,7 @@ class M3Mitigation():
         P = spla.LinearOperator((M.num_elems, M.num_elems), precond_matvec)
         vec = counts_to_vector(M.sorted_counts)
         out, error = spla.gmres(L, vec, tol=tol, atol=tol, maxiter=max_iter,
-                                M=P, callback=callback)
+                                M=P, callback=callback, callback_type='legacy')
         if error:
             raise M3Error('GMRES did not converge: {}'.format(error))
 

--- a/mthree/mitigation.py
+++ b/mthree/mitigation.py
@@ -163,6 +163,19 @@ class M3Mitigation():
             raise M3Error('Calibration currently in progress.')
         if qubits is None:
             qubits = range(self.num_qubits)
+            # Remove faulty qubits if any
+            if any(self.system_info['inoperable_qubits']):
+                qubits = list(filter(lambda item: item not in
+                    self.system_info['inoperable_qubits'], list(range(self.num_qubits))))
+                warnings.warn('Backend reporting inoperable qubits. ' + 
+                              'Skipping calibrations for: {}' \
+                                .format(self.system_info['inoperable_qubits']))
+
+        else:
+            inoperable_overlap = list(set(qubits) & set(self.system_info['inoperable_qubits']))
+            if any(inoperable_overlap):
+                raise M3Error('Attempting to calibrate inoperable qubits: {}' \
+                    .format(inoperable_overlap))
         if method is None:
             method = 'balanced'
             if self.system_info["simulator"]:

--- a/mthree/mitigation.py
+++ b/mthree/mitigation.py
@@ -166,8 +166,8 @@ class M3Mitigation():
             # Remove faulty qubits if any
             if any(self.system_info['inoperable_qubits']):
                 qubits = list(filter(lambda item: item not in
-                                self.system_info['inoperable_qubits'],
-                                list(range(self.num_qubits))))
+                                     self.system_info['inoperable_qubits'],
+                                     list(range(self.num_qubits))))
                 warnings.warn('Backend reporting inoperable qubits.' +
                               ' Skipping calibrations for: {}'
                                 .format(self.system_info['inoperable_qubits']))

--- a/mthree/mitigation.py
+++ b/mthree/mitigation.py
@@ -165,9 +165,9 @@ class M3Mitigation():
             qubits = range(self.num_qubits)
             # Remove faulty qubits if any
             if any(self.system_info['inoperable_qubits']):
-                qubits = list(filter(lambda item: item not in
-                                     self.system_info['inoperable_qubits'],
-                                     list(range(self.num_qubits))))
+                qubits = list(filter(lambda item: item not \
+                    in self.system_info['inoperable_qubits'],
+                    list(range(self.num_qubits))))
                 warnings.warn('Backend reporting inoperable qubits.' +
                               ' Skipping calibrations for: {}'
                                 .format(self.system_info['inoperable_qubits']))

--- a/mthree/mitigation.py
+++ b/mthree/mitigation.py
@@ -309,7 +309,7 @@ class M3Mitigation():
                 for item in qubits:
                     _qubits.extend(list(set(item.values())))
                 qubits = list(set(_qubits))
-    
+
         # Do check for inoperable qubits here
         inoperable_overlap = list(set(qubits) & set(self.system_info['inoperable_qubits']))
         if any(inoperable_overlap):

--- a/mthree/mitigation.py
+++ b/mthree/mitigation.py
@@ -166,10 +166,10 @@ class M3Mitigation():
             # Remove faulty qubits if any
             if any(self.system_info['inoperable_qubits']):
                 qubits = list(filter(lambda item: item not in
-                                      self.system_info['inoperable_qubits'],
-                                      list(range(self.num_qubits))))
+                                self.system_info['inoperable_qubits'],
+                                list(range(self.num_qubits))))
                 warnings.warn('Backend reporting inoperable qubits.' +
-                              ' Skipping calibrations for: {}' \
+                              ' Skipping calibrations for: {}'
                                 .format(self.system_info['inoperable_qubits']))
         if method is None:
             method = 'balanced'

--- a/mthree/mitigation.py
+++ b/mthree/mitigation.py
@@ -100,7 +100,7 @@ class M3Mitigation:
 
         # Reverse index qubits for easier indexing later
         for kk, qubit in enumerate(qubits[::-1]):
-            cals[4 * kk : 4 * kk + 4] = self.single_qubit_cals[qubit].ravel()
+            cals[4 * kk: 4 * kk + 4] = self.single_qubit_cals[qubit].ravel()
         return cals
 
     def _check_sdd(self, counts, qubits, distance=None):
@@ -406,9 +406,9 @@ class M3Mitigation:
         # Get the slice length
         circ_slice = num_circs // num_jobs + 1
         circs_list = [
-            trans_qcs[kk * circ_slice : (kk + 1) * circ_slice]
+            trans_qcs[kk * circ_slice: (kk + 1) * circ_slice]
             for kk in range(num_jobs - 1)
-        ] + [trans_qcs[(num_jobs - 1) * circ_slice :]]
+        ] + [trans_qcs[(num_jobs - 1) * circ_slice:]]
         # Do job submission here
         # This Backend check is here for Qiskit direct access.  Should be removed later.
         jobs = []

--- a/mthree/mitigation.py
+++ b/mthree/mitigation.py
@@ -313,8 +313,8 @@ class M3Mitigation():
         # Do check for inoperable qubits here
         inoperable_overlap = list(set(qubits) & set(self.system_info['inoperable_qubits']))
         if any(inoperable_overlap):
-            raise M3Error('Attempting to calibrate inoperable qubits: {}' \
-                .format(inoperable_overlap))
+            raise M3Error('Attempting to calibrate inoperable qubits: {}'
+                    .format(inoperable_overlap))
 
         num_cal_qubits = len(qubits)
         cal_strings = []

--- a/mthree/mitigation.py
+++ b/mthree/mitigation.py
@@ -167,7 +167,7 @@ class M3Mitigation():
             if any(self.system_info['inoperable_qubits']):
                 qubits = list(filter(lambda item: item not in
                     self.system_info['inoperable_qubits'], list(range(self.num_qubits))))
-                warnings.warn('Backend reporting inoperable qubits.' + 
+                warnings.warn('Backend reporting inoperable qubits.' +
                               ' Skipping calibrations for: {}' \
                                 .format(self.system_info['inoperable_qubits']))
 

--- a/mthree/mitigation.py
+++ b/mthree/mitigation.py
@@ -167,8 +167,8 @@ class M3Mitigation():
             if any(self.system_info['inoperable_qubits']):
                 qubits = list(filter(lambda item: item not in
                     self.system_info['inoperable_qubits'], list(range(self.num_qubits))))
-                warnings.warn('Backend reporting inoperable qubits. ' + 
-                              'Skipping calibrations for: {}' \
+                warnings.warn('Backend reporting inoperable qubits.' + 
+                              ' Skipping calibrations for: {}' \
                                 .format(self.system_info['inoperable_qubits']))
 
         else:

--- a/mthree/mitigation.py
+++ b/mthree/mitigation.py
@@ -25,8 +25,12 @@ import orjson
 from qiskit import execute
 from qiskit.providers import Backend, BackendV2, BackendV1
 
-from mthree.circuits import (_tensor_meas_states, _marg_meas_states,
-                             balanced_cal_strings, balanced_cal_circuits)
+from mthree.circuits import (
+    _tensor_meas_states,
+    _marg_meas_states,
+    balanced_cal_strings,
+    balanced_cal_circuits,
+)
 from mthree.matrix import _reduced_cal_matrix, sdd_check
 from mthree.utils import counts_to_vector, vector_to_quasiprobs
 from mthree.norms import ainv_onenorm_est_lu, ainv_onenorm_est_iter
@@ -36,8 +40,9 @@ from mthree.classes import QuasiCollection
 from ._helpers import system_info
 
 
-class M3Mitigation():
+class M3Mitigation:
     """Main M3 calibration class."""
+
     def __init__(self, system=None, iter_threshold=4096):
         """Main M3 calibration class.
 
@@ -59,7 +64,7 @@ class M3Mitigation():
         self.num_qubits = self.system_info["num_qubits"] if system else None
         self.iter_threshold = iter_threshold
         self.cal_shots = None
-        self.cal_method = 'balanced'
+        self.cal_method = "balanced"
         self.cal_timestamp = None  # The time at which the cals result was generated
         self.rep_delay = None
         # attributes for handling threaded job
@@ -75,9 +80,9 @@ class M3Mitigation():
 
         For certain attr this will join the thread and/or raise an error.
         """
-        __dict__ = super().__getattribute__('__dict__')
+        __dict__ = super().__getattribute__("__dict__")
         if attr in __dict__:
-            if attr in ['single_qubit_cals']:
+            if attr in ["single_qubit_cals"]:
                 self._thread_check()
         return super().__getattribute__(attr)
 
@@ -91,11 +96,11 @@ class M3Mitigation():
             ndarray: 1D Array of float cals data.
         """
         qubits = np.asarray(qubits, dtype=int)
-        cals = np.zeros(4*qubits.shape[0], dtype=float)
+        cals = np.zeros(4 * qubits.shape[0], dtype=float)
 
         # Reverse index qubits for easier indexing later
         for kk, qubit in enumerate(qubits[::-1]):
-            cals[4*kk:4*kk+4] = self.single_qubit_cals[qubit].ravel()
+            cals[4 * kk : 4 * kk + 4] = self.single_qubit_cals[qubit].ravel()
         return cals
 
     def _check_sdd(self, counts, qubits, distance=None):
@@ -120,13 +125,16 @@ class M3Mitigation():
         # check if len of bitstrings does not equal number of qubits passed.
         bitstring_len = len(next(iter(counts)))
         if bitstring_len != num_bits:
-            raise M3Error('Bitstring length ({}) does not match'.format(bitstring_len) +
-                          ' number of qubits ({})'.format(num_bits))
+            raise M3Error(
+                "Bitstring length ({}) does not match".format(bitstring_len)
+                + " number of qubits ({})".format(num_bits)
+            )
         cals = self._form_cals(qubits)
         return sdd_check(counts, cals, num_bits, distance)
 
-    def tensored_cals_from_system(self, qubits=None, shots=None,  method='balanced',
-                                  rep_delay=None, cals_file=None):
+    def tensored_cals_from_system(
+        self, qubits=None, shots=None, method="balanced", rep_delay=None, cals_file=None
+    ):
         """Grab calibration data from system.
 
         Parameters:
@@ -137,13 +145,24 @@ class M3Mitigation():
             cals_file (str): Output path to write JSON calibration data to.
         """
         warnings.warn("This method is deprecated, use 'cals_from_system' instead.")
-        self.cals_from_system(qubits=qubits, shots=shots, method=method,
-                              rep_delay=rep_delay,
-                              cals_file=cals_file)
+        self.cals_from_system(
+            qubits=qubits,
+            shots=shots,
+            method=method,
+            rep_delay=rep_delay,
+            cals_file=cals_file,
+        )
 
-    def cals_from_system(self, qubits=None, shots=None, method=None,
-                         initial_reset=False, rep_delay=None, cals_file=None,
-                         async_cal=False):
+    def cals_from_system(
+        self,
+        qubits=None,
+        shots=None,
+        method=None,
+        initial_reset=False,
+        rep_delay=None,
+        cals_file=None,
+        async_cal=False,
+    ):
         """Grab calibration data from system.
 
         Parameters:
@@ -160,28 +179,39 @@ class M3Mitigation():
             M3Error: Called while a calibration currently in progress.
         """
         if self._thread:
-            raise M3Error('Calibration currently in progress.')
+            raise M3Error("Calibration currently in progress.")
         if qubits is None:
             qubits = range(self.num_qubits)
             # Remove faulty qubits if any
-            if any(self.system_info['inoperable_qubits']):
-                qubits = list(filter(lambda item: item not \
-                    in self.system_info['inoperable_qubits'],
-                    list(range(self.num_qubits))))
-                warnings.warn('Backend reporting inoperable qubits.' +
-                              ' Skipping calibrations for: {}'
-                                .format(self.system_info['inoperable_qubits']))
+            if any(self.system_info["inoperable_qubits"]):
+                qubits = list(
+                    filter(
+                        lambda item: item not in self.system_info["inoperable_qubits"],
+                        list(range(self.num_qubits)),
+                    )
+                )
+                warnings.warn(
+                    "Backend reporting inoperable qubits."
+                    + " Skipping calibrations for: {}".format(
+                        self.system_info["inoperable_qubits"]
+                    )
+                )
         if method is None:
-            method = 'balanced'
+            method = "balanced"
             if self.system_info["simulator"]:
-                method = 'independent'
+                method = "independent"
         self.cal_method = method
         self.rep_delay = rep_delay
         self.cals_file = cals_file
         self.cal_timestamp = None
-        self._grab_additional_cals(qubits, shots=shots,  method=method,
-                                   rep_delay=rep_delay, initial_reset=initial_reset,
-                                   async_cal=async_cal)
+        self._grab_additional_cals(
+            qubits,
+            shots=shots,
+            method=method,
+            rep_delay=rep_delay,
+            initial_reset=initial_reset,
+            async_cal=async_cal,
+        )
 
     def cals_from_file(self, cals_file):
         """Generated the calibration data from a previous runs output
@@ -193,20 +223,22 @@ class M3Mitigation():
                 M3Error: Calibration in progress.
         """
         if self._thread:
-            raise M3Error('Calibration currently in progress.')
-        with open(cals_file, 'r', encoding='utf-8') as fd:
+            raise M3Error("Calibration currently in progress.")
+        with open(cals_file, "r", encoding="utf-8") as fd:
             loaded_data = orjson.loads(fd.read())
             if isinstance(loaded_data, dict):
-                self.single_qubit_cals = [np.asarray(cal) if cal else None
-                                          for cal in loaded_data['cals']]
-                self.cal_timestamp = loaded_data['timestamp']
-                self.cal_shots = loaded_data.get('shots', None)
+                self.single_qubit_cals = [
+                    np.asarray(cal) if cal else None for cal in loaded_data["cals"]
+                ]
+                self.cal_timestamp = loaded_data["timestamp"]
+                self.cal_shots = loaded_data.get("shots", None)
             else:
-                warnings.warn('Loading from old M3 file format.  Save again to update.')
+                warnings.warn("Loading from old M3 file format.  Save again to update.")
                 self.cal_timestamp = None
                 self.cal_shots = None
-                self.single_qubit_cals = [np.asarray(cal) if cal else None
-                                          for cal in loaded_data]
+                self.single_qubit_cals = [
+                    np.asarray(cal) if cal else None for cal in loaded_data
+                ]
         self.faulty_qubits = _faulty_qubit_checker(self.single_qubit_cals)
 
     def cals_to_file(self, cals_file=None):
@@ -220,16 +252,17 @@ class M3Mitigation():
             M3Error: Mitigator is not calibrated.
         """
         if not cals_file:
-            raise M3Error('cals_file must be explicitly set.')
+            raise M3Error("cals_file must be explicitly set.")
         if not self.single_qubit_cals:
-            raise M3Error('Mitigator is not calibrated.')
-        save_dict = {'timestamp': self.cal_timestamp,
-                     'backend': self.system_info.get("name", None),
-                     'shots': self.cal_shots,
-                     'cals': self.single_qubit_cals}
-        with open(cals_file, 'wb') as fd:
-            fd.write(orjson.dumps(save_dict,
-                                  option=orjson.OPT_SERIALIZE_NUMPY))
+            raise M3Error("Mitigator is not calibrated.")
+        save_dict = {
+            "timestamp": self.cal_timestamp,
+            "backend": self.system_info.get("name", None),
+            "shots": self.cal_shots,
+            "cals": self.single_qubit_cals,
+        }
+        with open(cals_file, "wb") as fd:
+            fd.write(orjson.dumps(save_dict, option=orjson.OPT_SERIALIZE_NUMPY))
 
     def tensored_cals_from_file(self, cals_file):
         """Generated the tensored calibration data from a previous runs output
@@ -255,8 +288,10 @@ class M3Mitigation():
         matrices = list(matrices)
         if self.num_qubits:
             if len(matrices) != self.num_qubits:
-                raise M3Error('Input list length not equal to'
-                              ' number of qubits {} != {}'.format(len(matrices), self.num_qubits))
+                raise M3Error(
+                    "Input list length not equal to"
+                    " number of qubits {} != {}".format(len(matrices), self.num_qubits)
+                )
         self.single_qubit_cals = matrices
         self.faulty_qubits = _faulty_qubit_checker(self.single_qubit_cals)
 
@@ -268,8 +303,15 @@ class M3Mitigation():
         """
         return self.single_qubit_cals.copy()
 
-    def _grab_additional_cals(self, qubits, shots=None, method='balanced', rep_delay=None,
-                              initial_reset=False, async_cal=False):
+    def _grab_additional_cals(
+        self,
+        qubits,
+        shots=None,
+        method="balanced",
+        rep_delay=None,
+        initial_reset=False,
+        async_cal=False,
+    ):
         """Grab missing calibration data from backend.
 
         Parameters:
@@ -287,7 +329,7 @@ class M3Mitigation():
         if self.system is None:
             raise M3Error("System is not set.  Use 'cals_from_file'.")
         if self.single_qubit_cals is None:
-            self.single_qubit_cals = [None]*self.num_qubits
+            self.single_qubit_cals = [None] * self.num_qubits
         if self.cal_shots is None:
             if shots is None:
                 shots = min(self.system_info["max_shots"], 10000)
@@ -295,8 +337,8 @@ class M3Mitigation():
         if self.rep_delay is None:
             self.rep_delay = rep_delay
 
-        if method not in ['independent', 'balanced', 'marginal']:
-            raise M3Error('Invalid calibration method.')
+        if method not in ["independent", "balanced", "marginal"]:
+            raise M3Error("Invalid calibration method.")
 
         if isinstance(qubits, dict):
             # Assuming passed a mapping
@@ -311,58 +353,74 @@ class M3Mitigation():
                 qubits = list(set(_qubits))
 
         # Do check for inoperable qubits here
-        inoperable_overlap = list(set(qubits) & set(self.system_info['inoperable_qubits']))
+        inoperable_overlap = list(
+            set(qubits) & set(self.system_info["inoperable_qubits"])
+        )
         if any(inoperable_overlap):
-            raise M3Error('Attempting to calibrate inoperable qubits: {}'
-                    .format(inoperable_overlap))
+            raise M3Error(
+                "Attempting to calibrate inoperable qubits: {}".format(
+                    inoperable_overlap
+                )
+            )
 
         num_cal_qubits = len(qubits)
         cal_strings = []
         # shots is needed here because balanced cals will use a value
         # different from cal_shots
         shots = self.cal_shots
-        if method == 'marginal':
-            trans_qcs = _marg_meas_states(qubits, self.num_qubits,
-                                          initial_reset=initial_reset)
+        if method == "marginal":
+            trans_qcs = _marg_meas_states(
+                qubits, self.num_qubits, initial_reset=initial_reset
+            )
 
-        elif method == 'balanced':
+        elif method == "balanced":
             cal_strings = balanced_cal_strings(num_cal_qubits)
-            trans_qcs = balanced_cal_circuits(cal_strings, qubits,
-                                              self.num_qubits,
-                                              initial_reset=initial_reset)
+            trans_qcs = balanced_cal_circuits(
+                cal_strings, qubits, self.num_qubits, initial_reset=initial_reset
+            )
             shots = (self.cal_shots + 1) // num_cal_qubits
         # Independent
         else:
             trans_qcs = []
             for kk in qubits:
-                trans_qcs.extend(_tensor_meas_states(kk, self.num_qubits,
-                                                     initial_reset=initial_reset))
+                trans_qcs.extend(
+                    _tensor_meas_states(
+                        kk, self.num_qubits, initial_reset=initial_reset
+                    )
+                )
 
         num_circs = len(trans_qcs)
         # check for max number of circuits per job
         if isinstance(self.system, BackendV1):
             # Aer simulator has no 'max_experiments'
-            max_circuits = getattr(self.system.configuration(), 'max_experiments', 300)
+            max_circuits = getattr(self.system.configuration(), "max_experiments", 300)
         elif isinstance(self.system, BackendV2):
             max_circuits = self.system.max_circuits
             # Needed for https://github.com/Qiskit/qiskit-terra/issues/9947
             if max_circuits is None:
                 max_circuits = 300
         else:
-            raise M3Error('Unknown backend type')
+            raise M3Error("Unknown backend type")
         # Determine the number of jobs required
         num_jobs = num_circs // max_circuits + 1
         # Get the slice length
         circ_slice = num_circs // num_jobs + 1
-        circs_list = [trans_qcs[kk*circ_slice:(kk+1)*circ_slice] for kk in range(num_jobs-1)] \
-            + [trans_qcs[(num_jobs-1)*circ_slice:]]
+        circs_list = [
+            trans_qcs[kk * circ_slice : (kk + 1) * circ_slice]
+            for kk in range(num_jobs - 1)
+        ] + [trans_qcs[(num_jobs - 1) * circ_slice :]]
         # Do job submission here
         # This Backend check is here for Qiskit direct access.  Should be removed later.
         jobs = []
         if not isinstance(self.system, Backend):
             for circs in circs_list:
-                _job = execute(circs, self.system, optimization_level=0,
-                               shots=shots, rep_delay=self.rep_delay)
+                _job = execute(
+                    circs,
+                    self.system,
+                    optimization_level=0,
+                    shots=shots,
+                    rep_delay=self.rep_delay,
+                )
                 jobs.append(_job)
         else:
             for circs in circs_list:
@@ -372,18 +430,26 @@ class M3Mitigation():
         # Execute job and cal building in new theread.
         self._job_error = None
         if async_cal:
-            thread = threading.Thread(target=_job_thread, args=(jobs, self, method, qubits,
-                                                                num_cal_qubits, cal_strings))
+            thread = threading.Thread(
+                target=_job_thread,
+                args=(jobs, self, method, qubits, num_cal_qubits, cal_strings),
+            )
             self._thread = thread
             self._thread.start()
         else:
             _job_thread(jobs, self, method, qubits, num_cal_qubits, cal_strings)
 
-    def apply_correction(self, counts, qubits, distance=None,
-                         method='auto',
-                         max_iter=25, tol=1e-5,
-                         return_mitigation_overhead=False,
-                         details=False):
+    def apply_correction(
+        self,
+        counts,
+        qubits,
+        distance=None,
+        method="auto",
+        max_iter=25,
+        tol=1e-5,
+        return_mitigation_overhead=False,
+        details=False,
+    ):
         """Applies correction to given counts.
 
         Parameters:
@@ -405,7 +471,7 @@ class M3Mitigation():
             M3Error: Bitstring length does not match number of qubits given.
         """
         if len(counts) == 0:
-            raise M3Error('Input counts is any empty dict.')
+            raise M3Error("Input counts is any empty dict.")
         given_list = False
         if isinstance(counts, (list, np.ndarray)):
             given_list = True
@@ -416,14 +482,14 @@ class M3Mitigation():
             # If a mapping was given for qubits
             qubits = [list(qubits.values())]
         elif not any(isinstance(qq, (list, tuple, np.ndarray, dict)) for qq in qubits):
-            qubits = [qubits]*len(counts)
+            qubits = [qubits] * len(counts)
         else:
             if isinstance(qubits[0], dict):
                 # assuming passed a list of mappings
                 qubits = [list(qu.values()) for qu in qubits]
 
         if len(qubits) != len(counts):
-            raise M3Error('Length of counts does not match length of qubits.')
+            raise M3Error("Length of counts does not match length of qubits.")
 
         # Check if using faulty qubits
         bad_qubits = set()
@@ -432,29 +498,38 @@ class M3Mitigation():
                 if qu in self.faulty_qubits:
                     bad_qubits.add(qu)
         if any(bad_qubits):
-            raise M3Error('Using faulty qubits: {}'.format(bad_qubits))
+            raise M3Error("Using faulty qubits: {}".format(bad_qubits))
 
         quasi_out = []
         for idx, cnts in enumerate(counts):
-
             quasi_out.append(
-                self._apply_correction(cnts, qubits=qubits[idx],
-                                       distance=distance,
-                                       method=method,
-                                       max_iter=max_iter, tol=tol,
-                                       return_mitigation_overhead=return_mitigation_overhead,
-                                       details=details)
-                            )
+                self._apply_correction(
+                    cnts,
+                    qubits=qubits[idx],
+                    distance=distance,
+                    method=method,
+                    max_iter=max_iter,
+                    tol=tol,
+                    return_mitigation_overhead=return_mitigation_overhead,
+                    details=details,
+                )
+            )
 
         if not given_list:
             return quasi_out[0]
         return QuasiCollection(quasi_out)
 
-    def _apply_correction(self, counts, qubits, distance=None,
-                          method='auto',
-                          max_iter=25, tol=1e-5,
-                          return_mitigation_overhead=False,
-                          details=False):
+    def _apply_correction(
+        self,
+        counts,
+        qubits,
+        distance=None,
+        method="auto",
+        max_iter=25,
+        tol=1e-5,
+        return_mitigation_overhead=False,
+        details=False,
+    ):
         """Applies correction to given counts.
 
         Parameters:
@@ -486,44 +561,50 @@ class M3Mitigation():
         # check if len of bitstrings does not equal number of qubits passed.
         bitstring_len = len(next(iter(counts)))
         if bitstring_len != num_bits:
-            raise M3Error('Bitstring length ({}) does not match'.format(bitstring_len) +
-                          ' number of qubits ({})'.format(num_bits))
+            raise M3Error(
+                "Bitstring length ({}) does not match".format(bitstring_len)
+                + " number of qubits ({})".format(num_bits)
+            )
 
         # Check if no cals done yet
         if self.single_qubit_cals is None:
-            warnings.warn('No calibration data. Calibrating: {}'.format(qubits))
+            warnings.warn("No calibration data. Calibrating: {}".format(qubits))
             self._grab_additional_cals(qubits, method=self.cal_method)
 
         # Check if one or more new qubits need to be calibrated.
         missing_qubits = [qq for qq in qubits if self.single_qubit_cals[qq] is None]
         if any(missing_qubits):
-            warnings.warn('Computing missing calibrations for qubits: {}'.format(missing_qubits))
+            warnings.warn(
+                "Computing missing calibrations for qubits: {}".format(missing_qubits)
+            )
             self._grab_additional_cals(missing_qubits, method=self.cal_method)
 
-        if method == 'auto':
+        if method == "auto":
             current_free_mem = psutil.virtual_memory().available / 1024**3
             # First check if direct method can be run
-            if num_elems <= self.iter_threshold \
-                    and ((num_elems**2+num_elems)*8/1024**3 < current_free_mem/2):
-                method = 'direct'
+            if num_elems <= self.iter_threshold and (
+                (num_elems**2 + num_elems) * 8 / 1024**3 < current_free_mem / 2
+            ):
+                method = "direct"
             else:
-                method = 'iterative'
+                method = "iterative"
 
-        if method == 'direct':
+        if method == "direct":
             st = perf_counter()
-            mit_counts, col_norms, gamma = self._direct_solver(counts, qubits, distance,
-                                                               return_mitigation_overhead)
-            dur = perf_counter()-st
+            mit_counts, col_norms, gamma = self._direct_solver(
+                counts, qubits, distance, return_mitigation_overhead
+            )
+            dur = perf_counter() - st
             mit_counts.shots = shots
             if gamma is not None:
                 mit_counts.mitigation_overhead = gamma * gamma
             if details:
-                info = {'method': 'direct', 'time': dur, 'dimension': num_elems}
-                info['col_norms'] = col_norms
+                info = {"method": "direct", "time": dur, "dimension": num_elems}
+                info["col_norms"] = col_norms
                 return mit_counts, info
             return mit_counts
 
-        elif method == 'iterative':
+        elif method == "iterative":
             iter_count = np.zeros(1, dtype=int)
 
             def callback(_):
@@ -531,33 +612,42 @@ class M3Mitigation():
 
             if details:
                 st = perf_counter()
-                mit_counts, col_norms, gamma = self._matvec_solver(counts,
-                                                                   qubits,
-                                                                   distance,
-                                                                   tol,
-                                                                   max_iter,
-                                                                   1,
-                                                                   callback,
-                                                                   return_mitigation_overhead)
-                dur = perf_counter()-st
+                mit_counts, col_norms, gamma = self._matvec_solver(
+                    counts,
+                    qubits,
+                    distance,
+                    tol,
+                    max_iter,
+                    1,
+                    callback,
+                    return_mitigation_overhead,
+                )
+                dur = perf_counter() - st
                 mit_counts.shots = shots
                 if gamma is not None:
                     mit_counts.mitigation_overhead = gamma * gamma
-                info = {'method': 'iterative', 'time': dur, 'dimension': num_elems}
-                info['iterations'] = iter_count[0]
-                info['col_norms'] = col_norms
+                info = {"method": "iterative", "time": dur, "dimension": num_elems}
+                info["iterations"] = iter_count[0]
+                info["col_norms"] = col_norms
                 return mit_counts, info
             # pylint: disable=unbalanced-tuple-unpacking
-            mit_counts, gamma = self._matvec_solver(counts, qubits, distance, tol,
-                                                    max_iter, 0, None,
-                                                    return_mitigation_overhead)
+            mit_counts, gamma = self._matvec_solver(
+                counts,
+                qubits,
+                distance,
+                tol,
+                max_iter,
+                0,
+                None,
+                return_mitigation_overhead,
+            )
             mit_counts.shots = shots
             if gamma is not None:
                 mit_counts.mitigation_overhead = gamma * gamma
             return mit_counts
 
         else:
-            raise M3Error('Invalid method: {}'.format(method))
+            raise M3Error("Invalid method: {}".format(method))
 
     def reduced_cal_matrix(self, counts, qubits, distance=None):
         """Return the reduced calibration matrix used in the solution.
@@ -584,15 +674,18 @@ class M3Mitigation():
         # check if len of bitstrings does not equal number of qubits passed.
         bitstring_len = len(next(iter(counts)))
         if bitstring_len != num_bits:
-            raise M3Error('Bitstring length ({}) does not match'.format(bitstring_len) +
-                          ' number of qubits ({})'.format(num_bits))
+            raise M3Error(
+                "Bitstring length ({}) does not match".format(bitstring_len)
+                + " number of qubits ({})".format(num_bits)
+            )
 
         cals = self._form_cals(qubits)
         A, counts, _ = _reduced_cal_matrix(counts, cals, num_bits, distance)
         return A, counts
 
-    def _direct_solver(self, counts, qubits, distance=None,
-                       return_mitigation_overhead=False):
+    def _direct_solver(
+        self, counts, qubits, distance=None, return_mitigation_overhead=False
+    ):
         """Apply the mitigation using direct LU factorization.
 
         Parameters:
@@ -606,7 +699,9 @@ class M3Mitigation():
         """
         cals = self._form_cals(qubits)
         num_bits = len(qubits)
-        A, sorted_counts, col_norms = _reduced_cal_matrix(counts, cals, num_bits, distance)
+        A, sorted_counts, col_norms = _reduced_cal_matrix(
+            counts, cals, num_bits, distance
+        )
         vec = counts_to_vector(sorted_counts)
         LU = la.lu_factor(A, check_finite=False)
         x = la.lu_solve(LU, vec, check_finite=False)
@@ -616,9 +711,17 @@ class M3Mitigation():
         out = vector_to_quasiprobs(x, sorted_counts)
         return out, col_norms, gamma
 
-    def _matvec_solver(self, counts, qubits, distance, tol=1e-5, max_iter=25,
-                       details=0, callback=None,
-                       return_mitigation_overhead=False):
+    def _matvec_solver(
+        self,
+        counts,
+        qubits,
+        distance,
+        tol=1e-5,
+        max_iter=25,
+        details=0,
+        callback=None,
+        return_mitigation_overhead=False,
+    ):
         """Compute solution using GMRES and Jacobi preconditioning.
 
         Parameters:
@@ -639,8 +742,9 @@ class M3Mitigation():
         """
         cals = self._form_cals(qubits)
         M = M3MatVec(dict(counts), cals, distance)
-        L = spla.LinearOperator((M.num_elems, M.num_elems),
-                                matvec=M.matvec, rmatvec=M.rmatvec)
+        L = spla.LinearOperator(
+            (M.num_elems, M.num_elems), matvec=M.matvec, rmatvec=M.rmatvec
+        )
         diags = M.get_diagonal()
 
         def precond_matvec(x):
@@ -649,10 +753,18 @@ class M3Mitigation():
 
         P = spla.LinearOperator((M.num_elems, M.num_elems), precond_matvec)
         vec = counts_to_vector(M.sorted_counts)
-        out, error = spla.gmres(L, vec, tol=tol, atol=tol, maxiter=max_iter,
-                                M=P, callback=callback, callback_type='legacy')
+        out, error = spla.gmres(
+            L,
+            vec,
+            tol=tol,
+            atol=tol,
+            maxiter=max_iter,
+            M=P,
+            callback=callback,
+            callback_type="legacy",
+        )
         if error:
-            raise M3Error('GMRES did not converge: {}'.format(error))
+            raise M3Error("GMRES did not converge: {}".format(error))
 
         gamma = None
         if return_mitigation_overhead:
@@ -677,14 +789,16 @@ class M3Mitigation():
             M3Error: Qubit indices out of range.
         """
         if self.single_qubit_cals is None:
-            raise M3Error('Mitigator is not calibrated')
+            raise M3Error("Mitigator is not calibrated")
 
         if qubits is None:
             qubits = range(self.num_qubits)
         else:
             outliers = [kk for kk in qubits if kk >= self.num_qubits]
             if any(outliers):
-                raise M3Error('One or more qubit indices out of range: {}'.format(outliers))
+                raise M3Error(
+                    "One or more qubit indices out of range: {}".format(outliers)
+                )
         fids = []
         for kk in qubits:
             qubit = self.single_qubit_cals[kk]
@@ -740,40 +854,40 @@ def _job_thread(jobs, mit, method, qubits, num_cal_qubits, cal_strings):
     mit.cal_timestamp = dt_utc.isoformat()
     # A list of qubits with bad meas cals
     bad_list = []
-    if method == 'independent':
+    if method == "independent":
         for idx, qubit in enumerate(qubits):
             mit.single_qubit_cals[qubit] = np.zeros((2, 2), dtype=float)
             # Counts 0 has all P00, P10 data, so do that here
-            prep0_counts = counts[2*idx]
-            P10 = prep0_counts.get('1', 0) / mit.cal_shots
-            P00 = 1-P10
+            prep0_counts = counts[2 * idx]
+            P10 = prep0_counts.get("1", 0) / mit.cal_shots
+            P00 = 1 - P10
             mit.single_qubit_cals[qubit][:, 0] = [P00, P10]
             # plus 1 here since zeros data at pos=0
-            prep1_counts = counts[2*idx+1]
-            P01 = prep1_counts.get('0', 0) / mit.cal_shots
-            P11 = 1-P01
+            prep1_counts = counts[2 * idx + 1]
+            P01 = prep1_counts.get("0", 0) / mit.cal_shots
+            P11 = 1 - P01
             mit.single_qubit_cals[qubit][:, 1] = [P01, P11]
             if P01 >= P00:
                 bad_list.append(qubit)
-    elif method == 'marginal':
+    elif method == "marginal":
         prep0_counts = counts[0]
         prep1_counts = counts[1]
         for idx, qubit in enumerate(qubits):
             mit.single_qubit_cals[qubit] = np.zeros((2, 2), dtype=float)
             count_vals = 0
-            index = num_cal_qubits-idx-1
+            index = num_cal_qubits - idx - 1
             for key, val in prep0_counts.items():
-                if key[index] == '0':
+                if key[index] == "0":
                     count_vals += val
             P00 = count_vals / mit.cal_shots
-            P10 = 1-P00
+            P10 = 1 - P00
             mit.single_qubit_cals[qubit][:, 0] = [P00, P10]
             count_vals = 0
             for key, val in prep1_counts.items():
-                if key[index] == '1':
+                if key[index] == "1":
                     count_vals += val
             P11 = count_vals / mit.cal_shots
-            P01 = 1-P11
+            P01 = 1 - P11
             mit.single_qubit_cals[qubit][:, 1] = [P01, P11]
             if P01 >= P00:
                 bad_list.append(qubit)
@@ -782,7 +896,6 @@ def _job_thread(jobs, mit, method, qubits, num_cal_qubits, cal_strings):
         cals = [np.zeros((2, 2), dtype=float) for kk in range(num_cal_qubits)]
 
         for idx, count in enumerate(counts):
-
             target = cal_strings[idx][::-1]
             good_prep = np.zeros(num_cal_qubits, dtype=float)
             denom = mit.cal_shots
@@ -794,7 +907,7 @@ def _job_thread(jobs, mit, method, qubits, num_cal_qubits, cal_strings):
                         good_prep[kk] += val
 
             for kk, cal in enumerate(cals):
-                if target[kk] == '0':
+                if target[kk] == "0":
                     cal[0, 0] += good_prep[kk] / denom
                 else:
                     cal[1, 1] += good_prep[kk] / denom

--- a/mthree/test/test_inoperable_qubits.py
+++ b/mthree/test/test_inoperable_qubits.py
@@ -30,11 +30,11 @@ def test_inoperable_qubits1():
     mit = mthree.M3Mitigation(BACKEND)
     mit.cals_from_system()
     for qubit in _faulty():
-        assert mit.single_qubit_cals[qubit] == None
+        assert mit.single_qubit_cals[qubit] is None
 
 
 def test_inoperable_qubits2():
     """Test that explicitly using inoperable qubits raises error"""
     mit = mthree.M3Mitigation(BACKEND)
-    with pytest.raises(M3Error):
+    with pytest.raises(mthree.exceptions.M3Error):
         mit.cals_from_system([0, 3])

--- a/mthree/test/test_inoperable_qubits.py
+++ b/mthree/test/test_inoperable_qubits.py
@@ -1,0 +1,40 @@
+# This code is part of Mthree.
+#
+# (C) Copyright IBM 2023.
+#
+# This code is licensed under the Apache License, Version 2.0. You may
+# obtain a copy of this license in the LICENSE.txt file in the root directory
+# of this source tree or at http://www.apache.org/licenses/LICENSE-2.0.
+#
+# Any modifications or derivative works of this code must retain this
+# copyright notice, and modified files need to carry a notice indicating
+# that they have been altered from the originals.
+
+"""Test inoperable qubits"""
+import pytest
+from qiskit.providers.fake_provider import FakeKolkata
+import mthree
+
+
+def _faulty():
+    return [1, 3, 5, 7]
+
+
+BACKEND = FakeKolkata()
+_ = BACKEND.properties()
+BACKEND._properties.faulty_qubits = _faulty
+
+
+def test_inoperable_qubits1():
+    """Test that inoperable qubits are ignored"""
+    mit = mthree.M3Mitigation(BACKEND)
+    mit.cals_from_system()
+    for qubit in _faulty():
+        assert mit.single_qubit_cals[qubit] == None
+
+
+def test_inoperable_qubits2():
+    """Test that explicitly using inoperable qubits raises error"""
+    mit = mthree.M3Mitigation(BACKEND)
+    with pytest.raises(M3Error):
+        mit.cals_from_system([0, 3])


### PR DESCRIPTION
IBM Quantum systems are now reporting faulty qubits in some cases.  This PR will make it so those qubits are not calibrated by default when no qubits are explicitly passed.  Additionally, if an user tries to explicitly calibrate faulty qubits then an `M3Error` is raised.