### PR TITLE
Faulty qubits gives warning not raises

### DIFF
--- a/mthree/mitigation.py
+++ b/mthree/mitigation.py
@@ -502,7 +502,7 @@ class M3Mitigation:
                 if qu in self.faulty_qubits:
                     bad_qubits.add(qu)
         if any(bad_qubits):
-            raise M3Error("Using faulty qubits: {}".format(bad_qubits))
+            warnings.warn("Using faulty qubits: {}".format(bad_qubits))
 
         quasi_out = []
         for idx, cnts in enumerate(counts):

--- a/mthree/test/test_faulty.py
+++ b/mthree/test/test_faulty.py
@@ -13,27 +13,8 @@
 
 """Test faulty qubits handling"""
 import numpy as np
-import pytest
 
 import mthree
-
-
-def test_faulty_logic():
-    """Test faulty qubits block correction"""
-
-    mit = mthree.M3Mitigation(None)
-    mit.single_qubit_cals = [np.array([[0.9819, 0.043],
-                                       [0.0181, 0.957]]),
-                             np.array([[0.4849, 0.5233],
-                                       [0.5151, 0.4767]]),
-                             np.array([[0.9092, 0.4021],
-                                       [0.0908, 0.5979]]),
-                             np.array([[0.4117, 0.8101],
-                                       [0.5883, 0.1899]])]
-    mit.faulty_qubits = [1, 3]
-    counts = {"00": 0.4, "01": 0.1, "11": 0.5}
-    with pytest.raises(mthree.exceptions.M3Error) as _:
-        _ = mit.apply_correction(counts, qubits=[3, 2])
 
 
 def test_faulty_io():

--- a/mthree/test/test_faulty.py
+++ b/mthree/test/test_faulty.py
@@ -34,8 +34,9 @@ def test_faulty_logic():
     counts = {"00": 0.4, "01": 0.1, "11": 0.5}
     with pytest.warns(UserWarning) as record:
         _ = mit.apply_correction(counts, qubits=[3, 2])
+
     assert len(record) == 1
-    assert 'faulty' in record[0].message.args[0]
+    assert record[0].message.args[0] == "Using faulty qubits: [3, 2]"
 
 
 def test_faulty_io():

--- a/mthree/test/test_faulty.py
+++ b/mthree/test/test_faulty.py
@@ -36,7 +36,7 @@ def test_faulty_logic():
         _ = mit.apply_correction(counts, qubits=[3, 2])
 
     assert len(record) == 1
-    assert record[0].message.args[0] == "Using faulty qubits: [3, 2]"
+    assert record[0].message.args[0] == "Using faulty qubits: {3}"
 
 
 def test_faulty_io():

--- a/mthree/test/test_faulty.py
+++ b/mthree/test/test_faulty.py
@@ -13,8 +13,29 @@
 
 """Test faulty qubits handling"""
 import numpy as np
+import pytest
 
 import mthree
+
+
+def test_faulty_logic():
+    """Test faulty qubits raise warning"""
+
+    mit = mthree.M3Mitigation(None)
+    mit.single_qubit_cals = [np.array([[0.9819, 0.043],
+                                       [0.0181, 0.957]]),
+                             np.array([[0.4849, 0.5233],
+                                       [0.5151, 0.4767]]),
+                             np.array([[0.9092, 0.4021],
+                                       [0.0908, 0.5979]]),
+                             np.array([[0.4117, 0.8101],
+                                       [0.5883, 0.1899]])]
+    mit.faulty_qubits = [1, 3]
+    counts = {"00": 0.4, "01": 0.1, "11": 0.5}
+    with pytest.warns(UserWarning) as record:
+        _ = mit.apply_correction(counts, qubits=[3, 2])
+    assert len(record) == 1
+    assert 'faulty' in record[0].message.args[0]
 
 
 def test_faulty_io():


### PR DESCRIPTION
It was requested to turn the faulty qubit error msg into a warning.  This was old behavior when originally looking into strict diagonal dominance.  We do not need that condition anymore with the more advanced methods now used, but it was still useful for identifying qubits with readouts that were close to random, or inverted from where they should be.  M3 should still probably work in these cases, but it is still a somewhat open question.