### PR TITLE
Upgrade to qiskit_sphinx_theme 1.12 and Sphinx 7

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,7 @@
 ---
 name: Docs Publish
 on:
+  workflow_dispatch:
   push:
     tags:
       - "*"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,7 +2,7 @@ qiskit>=0.28
 pytest
 pylint
 pycodestyle
-Sphinx~=7
+Sphinx>=7.0,<=8
 qiskit_sphinx_theme~=1.12.0
 matplotlib
 pylatexenc

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -2,8 +2,8 @@ qiskit>=0.28
 pytest
 pylint
 pycodestyle
-Sphinx<6
-qiskit_sphinx_theme~=1.11.1
+Sphinx~=7
+qiskit_sphinx_theme~=1.12.0
 matplotlib
 pylatexenc
 jupyter-sphinx

--- a/tox.ini
+++ b/tox.ini
@@ -24,3 +24,9 @@ changedir = {toxinidir}/docs
 allowlist_externals = make
 envdir = .tox/docs
 commands = make html
+
+[testenv:docs-clean]
+skip_install = true
+deps =
+allowlist_externals = rm
+commands = rm -rf {toxinidir}/docs/stubs/ {toxinidir}/docs/_build


### PR DESCRIPTION
The 1.12 theme release is focused on stability, including fixing 6 long-standing styling issues. See https://github.com/Qiskit/qiskit_sphinx_theme/releases/tag/1.12.0rc1 for the changelog.

This PR also:

* Pins Sphinx to 7. It brings some bug fixes and improvements from Sphinx 5. We pin to 7 to avoid breakage from Sphinx 8's release.
* Adds `tox -e docs-clean` to fix when autodoc has bad state.
* Allows an admin to trigger a docs deploy manually in GitHub's UI.