### PR TITLE
Fix issues when max_experiments = 1

### DIFF
--- a/mthree/mitigation.py
+++ b/mthree/mitigation.py
@@ -15,6 +15,7 @@
 import warnings
 import threading
 import datetime
+from math import ceil
 from time import perf_counter
 
 import psutil
@@ -406,9 +407,9 @@ class M3Mitigation:
         else:
             raise M3Error("Unknown backend type")
         # Determine the number of jobs required
-        num_jobs = num_circs // max_circuits + 1
+        num_jobs = ceil(num_circs / max_circuits)
         # Get the slice length
-        circ_slice = num_circs // num_jobs + 1
+        circ_slice = ceil(num_circs / num_jobs)
         circs_list = [
             trans_qcs[kk * circ_slice: (kk + 1) * circ_slice]
             for kk in range(num_jobs - 1)

--- a/mthree/mitigation.py
+++ b/mthree/mitigation.py
@@ -856,7 +856,11 @@ def _job_thread(jobs, mit, qubits, num_cal_qubits, cal_strings):
             return
         else:
             _counts = res.get_counts()
-            counts.extend(_counts)
+            # _counts can be a list or a dict (if only one circuit was executed within the job)
+            if isinstance(_counts, list):
+                counts.extend(_counts)
+            else:
+                counts.append(_counts)
     # attach timestamp
     timestamp = res.date
     # Needed since Aer result date is str but IBMQ job is datetime

--- a/mthree/test/test_multi_job.py
+++ b/mthree/test/test_multi_job.py
@@ -23,3 +23,13 @@ def test_multiple_job_submission():
     mit = mthree.M3Mitigation(backend)
     mit.cals_from_system()
     assert all(cal.trace() > 1.8 for cal in mit.single_qubit_cals)
+
+
+def test_multiple_job_submission_single_circuit():
+    """Test that submitting multiple single-circuit jobs works"""
+    backend = FakeKolkata()
+    _ = backend.configuration()
+    backend._configuration.max_experiments = 1
+    mit = mthree.M3Mitigation(backend)
+    mit.cals_from_system()
+    assert all(cal.trace() > 1.8 for cal in mit.single_qubit_cals)


### PR DESCRIPTION
When a backend configuration specifies `max_experiments` and this number divides the number of calibration circuits, an empty job would have been created (e.g., when `max_experiments = 1`). This PR fixes this issue, as well as another issue in the job thread that arises with single-circuit jobs. I also added a test case for this.