### PR TITLE
Fix datetime error when result.date is None

### DIFF
--- a/mthree/mitigation.py
+++ b/mthree/mitigation.py
@@ -858,6 +858,9 @@ def _job_thread(jobs, mit, qubits, num_cal_qubits, cal_strings):
             counts.extend(_counts)
     # attach timestamp
     timestamp = res.date
+    # Timestamp can be None
+    if timestamp is None:
+        timestampe = datetime.datetime.now()
     # Needed since Aer result date is str but IBMQ job is datetime
     if isinstance(timestamp, datetime.datetime):
         timestamp = timestamp.isoformat()

--- a/mthree/mitigation.py
+++ b/mthree/mitigation.py
@@ -860,7 +860,7 @@ def _job_thread(jobs, mit, qubits, num_cal_qubits, cal_strings):
     timestamp = res.date
     # Timestamp can be None
     if timestamp is None:
-        timestampe = datetime.datetime.now()
+        timestamp = datetime.datetime.now()
     # Needed since Aer result date is str but IBMQ job is datetime
     if isinstance(timestamp, datetime.datetime):
         timestamp = timestamp.isoformat()


### PR DESCRIPTION
The `result.date` can be None, in this case the datetime format conversion raises an error. I set the timestamp to `datetime.datetime.now()` in this case.