### PR TITLE
Add qiskit-aer to dev requirements

### DIFF
--- a/mthree/test/test_dynamic.py
+++ b/mthree/test/test_dynamic.py
@@ -35,13 +35,14 @@ def test_dynamic_bv():
     # Verify that mapping is returning the same qubit (1)
     # for all the classical bits
     mapping = mthree.utils.final_measurement_mapping(trans_qc)
-    assert mapping == {0: 25, 1: 25, 2: 25, 3: 25, 4: 25}
+    qubit_list = list(set(mapping.values()))
+    assert len(qubit_list) == 1
 
     mit = mthree.M3Mitigation(backend)
     mit.cals_from_system(mapping, method='independent')
     # Check that only the 1 qubit is populated in the cals
     for idx, mat in enumerate(mit.single_qubit_cals):
-        if idx == 25:
+        if idx == qubit_list[0]:
             assert mat is not None
         else:
             assert mat is None

--- a/mthree/test/test_dynamic.py
+++ b/mthree/test/test_dynamic.py
@@ -41,7 +41,7 @@ def test_dynamic_bv():
     mit.cals_from_system(mapping, method='independent')
     # Check that only the 1 qubit is populated in the cals
     for idx, mat in enumerate(mit.single_qubit_cals):
-        if idx == 1:
+        if idx == 25:
             assert mat is not None
         else:
             assert mat is None

--- a/mthree/test/test_dynamic.py
+++ b/mthree/test/test_dynamic.py
@@ -35,7 +35,7 @@ def test_dynamic_bv():
     # Verify that mapping is returning the same qubit (1)
     # for all the classical bits
     mapping = mthree.utils.final_measurement_mapping(trans_qc)
-    assert mapping == {0: 1, 1: 1, 2: 1, 3: 1, 4: 1}
+    assert mapping == {0: 25, 1: 25, 2: 25, 3: 25, 4: 25}
 
     mit = mthree.M3Mitigation(backend)
     mit.cals_from_system(mapping, method='independent')

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,5 @@
 qiskit>=0.28
+qiskit-aer
 pytest
 pylint
 pycodestyle


### PR DESCRIPTION
Qiskit Aer is no longer bundled with Qiskit.  This breaks most of the tests.  Here I explicitly add `qiskit-aer` to the dev requirements